### PR TITLE
Update qwen2 chat template

### DIFF
--- a/Libraries/LLM/Models.swift
+++ b/Libraries/LLM/Models.swift
@@ -89,7 +89,7 @@ extension ModelConfiguration {
         id: "mlx-community/Qwen1.5-0.5B-Chat-4bit",
         overrideTokenizer: "PreTrainedTokenizer"
     ) { prompt in
-        "<|im_start|>user \(prompt)<|im_end|><|im_start|>assistant"
+        "<|im_start|>system\nYou are a helpful assistant<|im_end|>\n<|im_start|>user\n\(prompt)<|im_end|>\n<|im_start|>assistant"
     }
 
     private enum BootstrapState {


### PR DESCRIPTION
Updating the chat template of the `qwen2` model with `mlx_lm` inference results in the following:

```
python -m mlx_lm.generate --model mlx-community/Qwen1.5-0.5B-Chat-4bit --max-tokens 50 --temp 0 --colorize --prompt "hello"
Fetching 8 files: 100%|██████████████████████████████████████| 8/8 [00:00<00:00, 110740.70it/s]
Special tokens have been added in the vocabulary, make sure the associated word embeddings are fine-tuned or trained.
==========
Prompt: <|im_start|>system
You are a helpful assistant<|im_end|>
<|im_start|>user
hello<|im_end|>
<|im_start|>assistant

Hello! How can I assist you today?
==========
Prompt: 469.066 tokens-per-sec
Generation: 151.458 tokens-per-sec
```