### PR TITLE
make it _much_ easier to run command line tools from the command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,19 @@ Example [MLX Swift](https://github.com/ml-explore/mlx-swift) programs.
 
 - [mnist-tool](Tools/mnist-tool/README.md): A command line tool for training a
   a LeNet on MNIST.
+  
+## Running
 
+The application and command line tool examples can be run from Xcode or from
+the command line:
+
+```
+./mlx-run llm-tool --prompt "swift programming language"
+```
+
+See also:
+
+- [MLX troubleshooting](https://ml-explore.github.io/mlx-swift/MLX/documentation/mlx/troubleshooting)
 
 ## Installation of MLXLLM and MLXMNIST libraries
 

--- a/Tools/llm-tool/README.md
+++ b/Tools/llm-tool/README.md
@@ -32,16 +32,18 @@ See [LLM](../../Libraries/LLM/README.md) for more info.
 
 ### Running (Command Line)
 
-`llm-tool` can also be run from the command line if built from Xcode, but 
-the `DYLD_FRAMEWORK_PATH` must be set so that the frameworks and bundles can be found:
+Use the `mlx-run` script to run the command line tools:
+
+```
+./mlx-run llm-tool --prompt "swift programming language"
+```
+
+By default this will find and run the tools built in _Release_ configuration.  Specify `--debug`
+to find and run the tool built in _Debug_ configuration.
+
+See also:
 
 - [MLX troubleshooting](https://ml-explore.github.io/mlx-swift/MLX/documentation/mlx/troubleshooting)
-
-The easiest way to do this is drag the Products/llm-tool into Terminal to get the path:
-
-```
-DYLD_FRAMEWORK_PATH=~/Library/Developer/Xcode/DerivedData/mlx-examples-swift-ceuohnhzsownvsbbleukxoksddja/Build/Products/Debug ~/Library/Developer/Xcode/DerivedData/mlx-examples-swift-ceuohnhzsownvsbbleukxoksddja/Build/Products/Debug/llm-tool --prompt "swift programming language"
-```
 
 ### Troubleshooting
 

--- a/Tools/mnist-tool/README.md
+++ b/Tools/mnist-tool/README.md
@@ -24,11 +24,15 @@ Then cmd-r to run.
 
 ### Running (CommandLine)
 
-`mnist-tool` can also be run from the command line if built from Xcode, but 
-the `DYLD_FRAMEWORK_PATH` must be set so that the frameworks and bundles can be found:
+Use the `mlx-run` script to run the command line tools:
+
+```
+./mlx-run mnist-tool --data /tmp
+```
+
+By default this will find and run the tools built in _Release_ configuration.  Specify `--debug`
+to find and run the tool built in _Debug_ configuration.
+
+See also:
 
 - [MLX troubleshooting](https://ml-explore.github.io/mlx-swift/MLX/documentation/mlx/troubleshooting)
-
-```
-DYLD_FRAMEWORK_PATH=~/Library/Developer/Xcode/DerivedData/mlx-examples-swift-ceuohnhzsownvsbbleukxoksddja/Build/Products/Debug ~/Library/Developer/Xcode/DerivedData/mlx-examples-swift-ceuohnhzsownvsbbleukxoksddja/Build/Products/Debug/mnist-tool --data /tmp
-```

--- a/mlx-run
+++ b/mlx-run
@@ -1,0 +1,45 @@
+#!/bin/sh
+
+# Wrapper to help run command line tools -- this will find the build directory
+# and set the DYLD_FRAMEWORK_PATH so that command line tools that link frameworks
+# can be run.
+#
+# Example:
+# ./mlx-run --debug llm-tool --help
+
+if [ "$#" -lt 1 ]; then
+	echo "usage: mlx-run [--debug/--release] <tool-name> arguments"
+	exit 1
+fi
+
+CONFIGURATION=Release
+if [ "$1" == "--release" ]; then
+	CONFIGURATION=Release
+	shift
+fi
+if [ "$1" == "--debug" ]; then
+	CONFIGURATION=Debug
+	shift
+fi
+if [ "$1" == "--list" ]; then
+	xcodebuild -list
+	exit 0
+fi
+
+COMMAND="$1"
+shift
+
+BUILD_DIR=`xcodebuild -configuration $CONFIGURATION -showBuildSettings -scheme $COMMAND | grep 'BUILT_PRODUCTS_DIR = /' | sed -e 's/^[^=]*= //g'`
+
+if [ -d "$BUILD_DIR/$COMMAND.app" ]; then
+	exec $BUILD_DIR/$COMMAND.app/Contents/MacOS/$COMMAND "$@" &
+fi
+
+if [ -f "$BUILD_DIR/$COMMAND" ]; then
+	export DYLD_FRAMEWORK_PATH=$BUILD_DIR/PackageFrameworks:$BUILD_DIR
+	exec "$BUILD_DIR/$COMMAND" "$@"
+else
+	echo "$BUILD_DIR/$COMMAND does not exist -- check build configuration ($CONFIGURATION)"
+	exit 1
+fi
+


### PR DESCRIPTION
Instead of using a command line like this:

```
DYLD_FRAMEWORK_PATH=/Users/dkoski/Library/Developer/Xcode/DerivedData/mlx-swift-examples-eimbjcofifunwybkcvhnzjbqwyri/Build/Products/Release/PackageFrameworks:/Users/dkoski/Library/Developer/Xcode/DerivedData/mlx-swift-examples-eimbjcofifunwybkcvhnzjbqwyri/Build/Products/Release  /Users/dkoski/Library/Developer/Xcode/DerivedData/mlx-swift-examples-eimbjcofifunwybkcvhnzjbqwyri/Build/Products/Release/llm-tool --prompt hello
```

use this:

```
./mlx-run llm-tool --prompt howdy
```