### PR TITLE
remove the bias in the ffn module for the OpenELM model

### DIFF
--- a/Libraries/LLM/OpenELM.swift
+++ b/Libraries/LLM/OpenELM.swift
@@ -106,8 +106,8 @@ private class FeedForwardNetwork: Module, UnaryLayer {
         let intermediateDim = Int(
             makeDivisible(Float(ffnMultiplier) * Float(dim), divisor: args.ffnDimDivisor))
 
-        self.proj_1 = Linear(dim, 2 * intermediateDim)
-        self.proj_2 = Linear(intermediateDim, dim)
+        self.proj_1 = Linear(dim, 2 * intermediateDim, bias: false)
+        self.proj_2 = Linear(intermediateDim, dim, bias: false)
     }
 
     public func callAsFunction(_ x: MLXArray) -> MLXArray {


### PR DESCRIPTION
I noticed a significant performance gap when running the `mlx-community/OpenELM-270M-Instruct` model between mlx-examples and mlx-swift-examples. Indeed, the speed was 18 t/s for swift and 77 t/s for python. This was due to the fact that the biases of the ffn layers were not deactivated and were therefore present in float32 precision.
This PR fixes the bias to false to avoid having biases.