### PR TITLE
Add Gemma 2

### DIFF
--- a/Libraries/LLM/Configuration.swift
+++ b/Libraries/LLM/Configuration.swift
@@ -32,6 +32,7 @@ public enum ModelType: String, Codable {
     case phi
     case phi3
     case gemma
+    case gemma2
     case qwen2
     case starcoder2
     case cohere
@@ -55,6 +56,10 @@ public enum ModelType: String, Codable {
             let configuration = try JSONDecoder().decode(
                 GemmaConfiguration.self, from: Data(contentsOf: configuration))
             return GemmaModel(configuration)
+        case .gemma2:
+            let configuration = try JSONDecoder().decode(
+                GemmaConfiguration.self, from: Data(contentsOf: configuration))
+            return Gemma2Model(configuration)
         case .qwen2:
             let configuration = try JSONDecoder().decode(
                 Qwen2Configuration.self, from: Data(contentsOf: configuration))

--- a/Libraries/LLM/Models.swift
+++ b/Libraries/LLM/Models.swift
@@ -157,6 +157,17 @@ extension ModelConfiguration {
         "<start_of_turn>user \(prompt)<end_of_turn><start_of_turn>model"
     }
 
+    public static let gemma_2_9b_it_4bit = ModelConfiguration(
+        id: "mlx-community/gemma-2-9b-it-4bit",
+        overrideTokenizer: "PreTrainedTokenizer",
+
+        // https://www.promptingguide.ai/models/gemma
+        defaultPrompt: "What is the difference between lettuce and cabbage?"
+
+    ) { prompt in
+        "<start_of_turn>user \(prompt)<end_of_turn><start_of_turn>model"
+    }
+
     public static let qwen205b4bit = ModelConfiguration(
         id: "mlx-community/Qwen1.5-0.5B-Chat-4bit",
         overrideTokenizer: "PreTrainedTokenizer",
@@ -200,6 +211,7 @@ extension ModelConfiguration {
                 phi4bit,
                 phi34bit,
                 gemma2bQuantized,
+                gemma_2_9b_it_4bit,
                 qwen205b4bit,
                 openelm270m4bit,
             ])


### PR DESCRIPTION
I tried using ChatGPT 4o to port the [Python implementation of Gemma 2](https://github.com/ml-explore/mlx-examples/blob/main/llms/mlx_lm/models/gemma2.py) over to Swift based on the Python and Swift implementations of the previous Gemma model. It's crashing at `matmul` due to a wrong tensor shape. If this isn't useful, just ignore it, but maybe there's just a small change that needs to be made.