### PR TITLE
Add SmolLM

### DIFF
--- a/Libraries/LLM/Models.swift
+++ b/Libraries/LLM/Models.swift
@@ -110,6 +110,13 @@ public struct ModelConfiguration {
 }
 
 extension ModelConfiguration {
+    public static let smolLM_135M_4bit = ModelConfiguration(
+        id: "mlx-community/SmolLM-135M-Instruct-4bit",
+        defaultPrompt: "Tell me about the history of Spain."
+    ) {
+        prompt in
+        "<|im_start|>user\n\(prompt)<|im_end|>\n<|im_start|>assistant\n"
+    }
 
     public static let mistral7B4bit = ModelConfiguration(
         id: "mlx-community/Mistral-7B-v0.1-hf-4bit-mlx",


### PR DESCRIPTION
I tried to get the SmolLM models working in Swift, but the output is garbled:

> conclusive Request harbourEntry Wizardlr speculationoglyph screw Februaryaco augmented explos Rexask Transaction acetyl manually Unique enzymesanan dirtyExplain LikDR anybody luxuryblue Buildings Examine grew Fed legacyarring frontiers pronounced sprinkle ...


It looks like there's a problem with the tokenizer. These models work fine in the Python MLX library. Any idea what changes would be needed to make this work?