### PR TITLE
Add SuScaledRotaryEmbedding for Phi 3.5

### DIFF
--- a/Applications/LLMEval/ContentView.swift
+++ b/Applications/LLMEval/ContentView.swift
@@ -157,9 +157,9 @@ class LLMEvaluator {
     var modelInfo = ""
     var stat = ""
 
-    /// this controls which model loads -- phi4bit is one of the smaller ones so this will fit on
-    /// more devices
-    let modelConfiguration = ModelConfiguration.phi3_4bit
+    /// This controls which model loads. `phi3_5_4bit` is one of the smaller ones, so this will fit on
+    /// more devices.
+    let modelConfiguration = ModelConfiguration.phi3_5_4bit
 
     /// parameters controlling the output
     let generateParameters = GenerateParameters(temperature: 0.6)

--- a/Libraries/LLM/Models.swift
+++ b/Libraries/LLM/Models.swift
@@ -154,9 +154,9 @@ extension ModelConfiguration {
         defaultPrompt: "Why is the sky blue?"
     )
 
-    public static let phi3_4bit = ModelConfiguration(
-        id: "mlx-community/Phi-3-mini-4k-instruct-4bit-no-q-embed",
-        defaultPrompt: "what is the gravity on mars and the moon?",
+    public static let phi3_5_4bit = ModelConfiguration(
+        id: "mlx-community/Phi-3.5-mini-instruct-4bit",
+        defaultPrompt: "What is the gravity on Mars and the moon?",
         extraEOSTokens: ["<|end|>"]
     ) {
         prompt in
@@ -250,7 +250,7 @@ extension ModelConfiguration {
                 mistral7B4bit,
                 codeLlama13b4bit,
                 phi4bit,
-                phi3_4bit,
+                phi3_5_4bit,
                 gemma2bQuantized,
                 gemma_2_9b_it_4bit,
                 qwen205b4bit,

--- a/Libraries/LLM/SuScaledRotaryEmbedding.swift
+++ b/Libraries/LLM/SuScaledRotaryEmbedding.swift
@@ -1,0 +1,50 @@
+import Foundation
+import MLX
+import MLXFast
+import MLXNN
+
+public class SuScaledRotaryEmbedding: Module {
+    let dimensions: Int
+    let base: Float
+    let maxPositionEmbeddings: Int
+    let originalMaxPositionEmbeddings: Int
+    let scale: Float
+    let _freqs: MLXArray
+
+    public init(
+        dimensions: Int,
+        base: Float = 10000.0,
+        maxPositionEmbeddings: Int = 131072,
+        originalMaxPositionEmbeddings: Int = 4096,
+        longFactor: [Float] = [1.0]
+    ) {
+        precondition(dimensions % 2 == 0, "Dimensions must be even")
+
+        self.dimensions = dimensions
+        self.base = base
+        self.maxPositionEmbeddings = maxPositionEmbeddings
+        self.originalMaxPositionEmbeddings = originalMaxPositionEmbeddings
+
+        let exponent =
+            MLXArray(stride(from: 0, to: dimensions, by: 2)).asType(.float32) / Float(dimensions)
+        let freqs = MLX.pow(MLXArray(base), exponent)
+        self._freqs = MLXArray(longFactor).asType(.float32) * freqs
+
+        self.scale = sqrt(
+            1 + log(Float(maxPositionEmbeddings) / Float(originalMaxPositionEmbeddings))
+                / log(Float(originalMaxPositionEmbeddings))
+        )
+    }
+
+    public func callAsFunction(_ x: MLXArray, offset: Int = 0) -> MLXArray {
+        return MLXFast.RoPE(
+            self.scale * x,
+            dimensions: x.shape.last!,
+            traditional: false,
+            base: self.base,  // TODO: After updating to MLX 0.17.0, use `nil`
+            scale: 1.0,
+            offset: offset
+                // TODO: After updating to MLX 0.17.0, pass `self._freqs` to `freqs`
+        )
+    }
+}

--- a/mlx-swift-examples.xcodeproj/project.pbxproj
+++ b/mlx-swift-examples.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		7BBD0D6E2BE044A10019C5D7 /* OpenELM.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BBD0D6D2BE044A10019C5D7 /* OpenELM.swift */; };
 		81695B412BA373D300F260D8 /* MarkdownUI in Frameworks */ = {isa = PBXBuildFile; productRef = 81695B402BA373D300F260D8 /* MarkdownUI */; };
 		819BEFF82BAF8B4E0002CCEE /* DeviceStat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 819BEFF62BAF8B4E0002CCEE /* DeviceStat.swift */; };
+		927C784E2C7A578A001E5878 /* SuScaledRotaryEmbedding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 927C784D2C7A578A001E5878 /* SuScaledRotaryEmbedding.swift */; };
 		C3056BAE2BCD97B700A31D04 /* LoRATrainingExampleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3056BAD2BCD97B700A31D04 /* LoRATrainingExampleApp.swift */; };
 		C3056BB02BCD97B700A31D04 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3056BAF2BCD97B700A31D04 /* ContentView.swift */; };
 		C3056BB22BCD97B800A31D04 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C3056BB12BCD97B800A31D04 /* Assets.xcassets */; };
@@ -223,6 +224,7 @@
 		52A776172B94B5EE00AA6E80 /* Qwen2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Qwen2.swift; sourceTree = "<group>"; };
 		7BBD0D6D2BE044A10019C5D7 /* OpenELM.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OpenELM.swift; sourceTree = "<group>"; };
 		819BEFF62BAF8B4E0002CCEE /* DeviceStat.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeviceStat.swift; sourceTree = "<group>"; };
+		927C784D2C7A578A001E5878 /* SuScaledRotaryEmbedding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuScaledRotaryEmbedding.swift; sourceTree = "<group>"; };
 		C3056BA12BCD973400A31D04 /* test.jsonl */ = {isa = PBXFileReference; lastKnownFileType = text; path = test.jsonl; sourceTree = "<group>"; };
 		C3056BA22BCD973400A31D04 /* train.jsonl */ = {isa = PBXFileReference; lastKnownFileType = text; path = train.jsonl; sourceTree = "<group>"; };
 		C3056BA32BCD973400A31D04 /* valid.jsonl */ = {isa = PBXFileReference; lastKnownFileType = text; path = valid.jsonl; sourceTree = "<group>"; };
@@ -489,6 +491,7 @@
 				C3E786AC2B8D4AF50004D037 /* Tokenizer.swift */,
 				52A776172B94B5EE00AA6E80 /* Qwen2.swift */,
 				F24B08392BAF1A65008C8D19 /* Cohere.swift */,
+				927C784D2C7A578A001E5878 /* SuScaledRotaryEmbedding.swift */,
 			);
 			path = LLM;
 			sourceTree = "<group>";
@@ -1013,6 +1016,7 @@
 				1C55317A2C5AAB4E00B07ECD /* Gemma2.swift in Sources */,
 				C3E786AB2B8D1AEC0004D037 /* Evaluate.swift in Sources */,
 				C38935CC2B869C870037B833 /* Llama.swift in Sources */,
+				927C784E2C7A578A001E5878 /* SuScaledRotaryEmbedding.swift in Sources */,
 				52A776182B94B5EE00AA6E80 /* Qwen2.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
https://github.com/ml-explore/mlx-swift/pull/124

I haven't tested this with Phi 3.5 yet, but will do that tomorrow.