### PR TITLE
add kvcache, async eval, etc for #93

### DIFF
--- a/Libraries/LLM/Gemma2.swift
+++ b/Libraries/LLM/Gemma2.swift
@@ -59,8 +59,8 @@ private class Attention: Module {
     }
 
     public func callAsFunction(
-        _ x: MLXArray, mask: MLXArray? = nil, cache: (MLXArray, MLXArray)? = nil
-    ) -> (MLXArray, (MLXArray, MLXArray)) {
+        _ x: MLXArray, mask: MLXArray? = nil, cache: KVCache?
+    ) -> MLXArray {
         let (B, L) = (x.dim(0), x.dim(1))
 
         var queries = wq(x)
@@ -72,17 +72,14 @@ private class Attention: Module {
         keys = keys.reshaped(B, L, args.kvHeads, -1).transposed(0, 2, 1, 3)
         values = values.reshaped(B, L, args.kvHeads, -1).transposed(0, 2, 1, 3)
 
-        if let (keyCache, valueCache) = cache {
-            queries = rope(queries, offset: keyCache.dim(2))
-            keys = rope(keys, offset: keyCache.dim(2))
-            keys = concatenated([keyCache, keys], axis: 2)
-            values = concatenated([valueCache, values], axis: 2)
+        if let cache {
+            queries = rope(queries, offset: cache.offset)
+            keys = rope(keys, offset: cache.offset)
+            (keys, values) = cache.update(keys: keys, values: values)
         } else {
             queries = rope(queries)
             keys = rope(keys)
         }
-
-        let newCache = (keys, values)
 
         let repeats = self.args.attentionHeads / self.args.kvHeads
         if repeats > 1 {
@@ -105,7 +102,7 @@ private class Attention: Module {
             output = output.reshaped([B, self.args.attentionHeads, L, self.headDim])
         }
         output = output.transposed(0, 2, 1, 3).reshaped(B, L, -1)
-        return (wo(output), newCache)
+        return wo(output)
     }
 }
 
@@ -151,13 +148,13 @@ private class TransformerBlock: Module {
     }
 
     public func callAsFunction(
-        _ x: MLXArray, mask: MLXArray? = nil, cache: (MLXArray, MLXArray)? = nil
-    ) -> (MLXArray, (MLXArray, MLXArray)) {
-        var (r, cache) = attention(inputLayerNorm(x), mask: mask, cache: cache)
+        _ x: MLXArray, mask: MLXArray? = nil, cache: KVCache?
+    ) -> MLXArray {
+        var r = attention(inputLayerNorm(x), mask: mask, cache: cache)
         let h = x + postAttentionLayerNorm(r)
         r = mlp(preFeedforwardLayerNorm(h))
         let out = h + postFeedforwardLayerNorm(r)
-        return (out, cache)
+        return out
     }
 }
 
@@ -186,50 +183,43 @@ public class ModelInner: Module {
         self.norm = RMSNorm(dimensions: args.hiddenSize, eps: args.rmsNormEps)
     }
 
-    public func callAsFunction(_ inputs: MLXArray, cache: [(MLXArray, MLXArray)]? = nil) -> (
-        MLXArray, [(MLXArray, MLXArray)]
-    ) {
+    public func callAsFunction(_ inputs: MLXArray, cache: [KVCache]? = nil) -> MLXArray {
         var h = embedTokens(inputs)
         h = h * hiddenScale
 
-        var mask: MLXArray? = nil
-        if h.dim(1) > 1 {
-            mask = MultiHeadAttention.createAdditiveCausalMask(h.dim(1))
-            mask = mask?.asType(h.dtype)
-        }
-
-        var newCache = [(MLXArray, MLXArray)]()
+        let mask: MLXArray? = createAttentionMask(h: h, cache: cache)
 
         for (i, layer) in layers.enumerated() {
-            var cacheUpdate: (MLXArray, MLXArray)
-            (h, cacheUpdate) = layer(h, mask: mask, cache: cache?[i])
-            newCache.append(cacheUpdate)
+            h = layer(h, mask: mask, cache: cache?[i])
         }
 
-        return (norm(h), newCache)
+        return norm(h)
     }
 }
 
 // Uses Gemma2ModelInner, otherwise same as GemmaModel
-public class Gemma2Model: Module, LLMModel {
+public class Gemma2Model: Module, LLMModel, KVCacheDimensionProvider {
 
     public let vocabularySize: Int
+    public let kvHeads: [Int]
+    public let headDim: IntOrPair
+
     let model: ModelInner
     let logitSoftCap: Float
 
     public init(_ args: Gemma2Configuration) {
         self.vocabularySize = args.vocabularySize
+        self.kvHeads = (0 ..< args.hiddenLayers).map { _ in args.kvHeads }
+        self.headDim = .init(args.headDimensions)
         self.model = ModelInner(args)
         self.logitSoftCap = args.finalLogitSoftcapping
     }
 
-    public func callAsFunction(_ inputs: MLXArray, cache: [(MLXArray, MLXArray)]?) -> (
-        MLXArray, [(MLXArray, MLXArray)]
-    ) {
-        var (out, cache) = model(inputs, cache: cache)
+    public func callAsFunction(_ inputs: MLXArray, cache: [KVCache]?) -> MLXArray {
+        var out = model(inputs, cache: cache)
         out = model.embedTokens.asLinear(out)
         out = tanh(out / self.logitSoftCap) * self.logitSoftCap
-        return (out, cache)
+        return out
     }
 }
 

--- a/Libraries/LLM/KVCache.swift
+++ b/Libraries/LLM/KVCache.swift
@@ -1,0 +1,104 @@
+// Copyright © 2024 Apple Inc.
+
+import Foundation
+import MLX
+
+/// Interface for Key/Value cache for LLMs.
+///
+/// See ``LLMModel/newCache(parameters:)-47tyu``
+public protocol KVCache: Evaluatable {
+
+    /// get the current offset
+    var offset: Int { get }
+
+    func update(keys: MLXArray, values: MLXArray) -> (MLXArray, MLXArray)
+}
+
+func createAdditiveCausalMask(n: Int, offset: Int) -> MLXArray {
+    let rinds = MLXArray(Int32(0) ..< Int32(offset + n))
+    let linds = offset != 0 ? MLXArray(Int32(offset) ..< Int32(offset + n)) : rinds
+    let mask = linds[0..., .newAxis] .< rinds[.newAxis]
+    return mask * Float32(-1e9)
+}
+
+/// create an attention mask using the parameters from the KVCache.
+///
+/// See also ``MultiHeadAttention/createAdditiveCausalMask(_:dtype:)`` -- same idea
+/// but doesn't honor the cache offset.
+public func createAttentionMask(h: MLXArray, cache: [KVCache]?) -> MLXArray? {
+    let t = h.dim(1)
+    if t > 1 {
+        var offset = 0
+        if let c = cache?.first {
+            offset = c.offset
+        }
+        return createAdditiveCausalMask(n: t, offset: offset)
+            .asType(h.dtype)
+    }
+    return nil
+}
+
+/// See https://github.com/ml-explore/mlx-examples/blob/main/llms/mlx_lm/models/base.py#L11
+class KVCacheSimple: KVCache, Evaluatable {
+    let kHeadDim: Int
+    let vHeadDim: Int
+    let kvHeads: Int
+
+    var keys: MLXArray?
+    var values: MLXArray?
+
+    var offset = 0
+    var step = 256
+
+    init(headDim: IntOrPair, kvHeads: Int) {
+        self.kHeadDim = headDim.first
+        self.vHeadDim = headDim.second
+        self.kvHeads = kvHeads
+    }
+
+    public func innerState() -> [MLXArray] {
+        [self.keys, self.values].compactMap { $0 }
+    }
+
+    func update(keys: MLXArray, values: MLXArray) -> (MLXArray, MLXArray) {
+        let previous = self.offset
+
+        let reset =
+            if let currentKeys = self.keys, (previous + keys.dim(2)) > currentKeys.dim(2) {
+                true
+            } else {
+                self.keys == nil
+            }
+        if reset {
+            let B = keys.dim(0)
+            let nSteps = (step + keys.dim(2) - 1) / step
+            let kShape = [B, kvHeads, nSteps * step, kHeadDim]
+            let vShape = [B, kvHeads, nSteps * step, vHeadDim]
+            let newK = MLXArray.zeros(kShape, dtype: keys.dtype)
+            let newV = MLXArray.zeros(vShape, dtype: values.dtype)
+
+            if var currentKeys = self.keys, var currentValues = self.values {
+                if previous % step != 0 {
+                    currentKeys = currentKeys[.ellipsis, ..<previous, 0...]
+                    currentValues = currentValues[.ellipsis, ..<previous, 0...]
+                }
+                self.keys = concatenated([currentKeys, newK], axis: 2)
+                self.values = concatenated([currentValues, newV], axis: 2)
+            } else {
+                self.keys = newK
+                self.values = newV
+            }
+        }
+
+        self.offset += keys.dim(2)
+
+        self.keys?[.ellipsis, previous ..< self.offset, 0...] = keys
+        self.values?[.ellipsis, previous ..< self.offset, 0...] = values
+
+        return (
+            self.keys![.ellipsis, ..<self.offset, 0...],
+            self.values![.ellipsis, ..<self.offset, 0...]
+        )
+    }
+
+}

--- a/Libraries/LLM/Lora.swift
+++ b/Libraries/LLM/Lora.swift
@@ -438,7 +438,7 @@ public enum LoRATrain {
 
         // run model on inputs
         let model = model as! LLMModel
-        let logits = model(inputs, cache: nil).0.asType(.float32)
+        let logits = model(inputs, cache: nil).asType(.float32)
 
         // mask padding tokens
         let lengthMask = MLXArray(0 ..< inputs.dim(1))[.newAxis, 0...] .< lengths[0..., .newAxis]

--- a/Libraries/LLM/Phi3.swift
+++ b/Libraries/LLM/Phi3.swift
@@ -10,6 +10,10 @@ private class Attention: Module {
     let args: Phi3Configuration
     let scale: Float
 
+    let heads: Int
+    let kvHeads: Int
+    let headDim: Int
+
     @ModuleInfo(key: "qkv_proj") var wqkv: Linear
     @ModuleInfo(key: "o_proj") var wo: Linear
 
@@ -33,10 +37,10 @@ private class Attention: Module {
         self.args = args
 
         let dim = args.hiddenSize
-        let heads = args.attentionHeads
-        let kvHeads = args.kvHeads
+        self.heads = args.attentionHeads
+        self.kvHeads = args.kvHeads
 
-        let headDim = args.hiddenSize / heads
+        self.headDim = args.hiddenSize / heads
         self.scale = pow(Float(headDim), -0.5)
 
         self._wqkv.wrappedValue = Linear(dim, (heads + 2 * kvHeads) * headDim, bias: false)
@@ -71,12 +75,11 @@ private class Attention: Module {
         }
     }
 
-    public func callAsFunction(
-        _ x: MLXArray, mask: MLXArray? = nil, cache: (MLXArray, MLXArray)? = nil
-    ) -> (MLXArray, (MLXArray, MLXArray)) {
+    public func callAsFunction(_ x: MLXArray, mask: MLXArray? = nil, cache: KVCache?) -> MLXArray {
         let (B, L) = (x.dim(0), x.dim(1))
 
-        let qkv = split(wqkv(x), parts: 3, axis: -1)
+        let queryPos = heads * headDim
+        let qkv = split(wqkv(x), indices: [queryPos, queryPos + kvHeads * headDim], axis: -1)
         var queries = qkv[0]
         var keys = qkv[1]
         var values = qkv[2]
@@ -86,11 +89,10 @@ private class Attention: Module {
         keys = keys.reshaped(B, L, args.kvHeads, -1).transposed(0, 2, 1, 3)
         values = values.reshaped(B, L, args.kvHeads, -1).transposed(0, 2, 1, 3)
 
-        if let (keyCache, valueCache) = cache {
-            queries = rope.applyEncoding(queries, offset: keyCache.dim(2))
-            keys = rope.applyEncoding(keys, offset: keyCache.dim(2))
-            keys = concatenated([keyCache, keys], axis: 2)
-            values = concatenated([valueCache, values], axis: 2)
+        if let cache {
+            queries = rope.applyEncoding(queries, offset: cache.offset)
+            keys = rope.applyEncoding(keys, offset: cache.offset)
+            (keys, values) = cache.update(keys: keys, values: values)
         } else {
             queries = rope.applyEncoding(queries)
             keys = rope.applyEncoding(keys)
@@ -102,7 +104,7 @@ private class Attention: Module {
         .transposed(0, 2, 1, 3)
         .reshaped(B, L, -1)
 
-        return (wo(output), (keys, values))
+        return wo(output)
     }
 }
 
@@ -139,14 +141,12 @@ private class TransformerBlock: Module {
             dimensions: args.hiddenSize, eps: args.rmsNormEps)
     }
 
-    public func callAsFunction(
-        _ x: MLXArray, mask: MLXArray? = nil, cache: (MLXArray, MLXArray)? = nil
-    ) -> (MLXArray, (MLXArray, MLXArray)) {
-        var (r, cache) = attention(inputLayerNorm(x), mask: mask, cache: cache)
+    public func callAsFunction(_ x: MLXArray, mask: MLXArray? = nil, cache: KVCache?) -> MLXArray {
+        var r = attention(inputLayerNorm(x), mask: mask, cache: cache)
         let h = x + r
         r = mlp(postAttentionLayerNorm(h))
         let out = h + r
-        return (out, cache)
+        return out
     }
 }
 
@@ -170,47 +170,40 @@ public class Phi3ModelInner: Module {
         self.norm = RMSNorm(dimensions: args.hiddenSize, eps: args.rmsNormEps)
     }
 
-    public func callAsFunction(_ inputs: MLXArray, cache: [(MLXArray, MLXArray)]? = nil) -> (
-        MLXArray, [(MLXArray, MLXArray)]
-    ) {
+    public func callAsFunction(_ inputs: MLXArray, cache: [KVCache]?) -> MLXArray {
         var h = embedTokens(inputs)
 
-        var mask: MLXArray? = nil
-        if h.dim(1) > 1 {
-            mask = MultiHeadAttention.createAdditiveCausalMask(h.dim(1))
-            mask = mask?.asType(h.dtype)
-        }
-
-        var newCache = [(MLXArray, MLXArray)]()
+        let mask: MLXArray? = createAttentionMask(h: h, cache: cache)
 
         for (i, layer) in layers.enumerated() {
-            var cacheUpdate: (MLXArray, MLXArray)
-            (h, cacheUpdate) = layer(h, mask: mask, cache: cache?[i])
-            newCache.append(cacheUpdate)
+            h = layer(h, mask: mask, cache: cache?[i])
         }
 
-        return (norm(h), newCache)
+        return norm(h)
     }
 }
 
-public class Phi3Model: Module, LLMModel {
+public class Phi3Model: Module, LLMModel, KVCacheDimensionProvider {
 
     public let vocabularySize: Int
+    public let kvHeads: [Int]
+    public let headDim: IntOrPair
+
     let model: Phi3ModelInner
 
     @ModuleInfo(key: "lm_head") var lmHead: Linear
 
     public init(_ args: Phi3Configuration) {
         self.vocabularySize = args.vocabularySize
+        self.kvHeads = (0 ..< args.hiddenLayers).map { _ in args.kvHeads }
+        self.headDim = .init(args.hiddenSize / args.attentionHeads)
         self.model = Phi3ModelInner(args)
         self._lmHead.wrappedValue = Linear(args.hiddenSize, args.vocabularySize, bias: false)
     }
 
-    public func callAsFunction(_ inputs: MLXArray, cache: [(MLXArray, MLXArray)]?) -> (
-        MLXArray, [(MLXArray, MLXArray)]
-    ) {
-        let (out, cache) = model(inputs, cache: cache)
-        return (lmHead(out), cache)
+    public func callAsFunction(_ inputs: MLXArray, cache: [KVCache]?) -> MLXArray {
+        let out = model(inputs, cache: cache)
+        return lmHead(out)
     }
 }
 

--- a/Libraries/LLM/Starcoder2.swift
+++ b/Libraries/LLM/Starcoder2.swift
@@ -42,8 +42,8 @@ private class Attention: Module {
     }
 
     public func callAsFunction(
-        _ x: MLXArray, mask: MLXArray? = nil, cache: (MLXArray, MLXArray)? = nil
-    ) -> (MLXArray, (MLXArray, MLXArray)) {
+        _ x: MLXArray, mask: MLXArray? = nil, cache: KVCache?
+    ) -> MLXArray {
         let (B, L) = (x.dim(0), x.dim(1))
 
         var queries = wq(x)
@@ -55,11 +55,10 @@ private class Attention: Module {
         keys = keys.reshaped(B, L, args.kvHeads, -1).transposed(0, 2, 1, 3)
         values = values.reshaped(B, L, args.kvHeads, -1).transposed(0, 2, 1, 3)
 
-        if let (keyCache, valueCache) = cache {
-            queries = rope(queries, offset: keyCache.dim(2))
-            keys = rope(keys, offset: keyCache.dim(2))
-            keys = concatenated([keyCache, keys], axis: 2)
-            values = concatenated([valueCache, values], axis: 2)
+        if let cache {
+            queries = rope(queries, offset: cache.offset)
+            keys = rope(keys, offset: cache.offset)
+            (keys, values) = cache.update(keys: keys, values: values)
         } else {
             queries = rope(queries)
             keys = rope(keys)
@@ -71,7 +70,7 @@ private class Attention: Module {
         .transposed(0, 2, 1, 3)
         .reshaped(B, L, -1)
 
-        return (wo(output), (keys, values))
+        return wo(output)
     }
 }
 
@@ -106,13 +105,13 @@ private class TransformerBlock: Module {
     }
 
     public func callAsFunction(
-        _ x: MLXArray, mask: MLXArray? = nil, cache: (MLXArray, MLXArray)? = nil
-    ) -> (MLXArray, (MLXArray, MLXArray)) {
-        var (r, cache) = attention(inputLayerNorm(x), mask: mask, cache: cache)
+        _ x: MLXArray, mask: MLXArray? = nil, cache: KVCache?
+    ) -> MLXArray {
+        var r = attention(inputLayerNorm(x), mask: mask, cache: cache)
         let h = x + r
         r = mlp(postAttentionLayerNorm(h))
         let out = h + r
-        return (out, cache)
+        return out
     }
 }
 
@@ -135,31 +134,23 @@ public class Starcoder2ModelInner: Module {
         self.norm = LayerNorm(dimensions: args.hiddenSize, eps: args.normEpsilon)
     }
 
-    public func callAsFunction(_ inputs: MLXArray, cache: [(MLXArray, MLXArray)]? = nil) -> (
-        MLXArray, [(MLXArray, MLXArray)]
-    ) {
+    public func callAsFunction(_ inputs: MLXArray, cache: [KVCache]? = nil) -> MLXArray {
         var h = embedTokens(inputs)
 
-        var mask: MLXArray? = nil
-        if h.dim(1) > 1 {
-            mask = MultiHeadAttention.createAdditiveCausalMask(h.dim(1))
-            mask = mask?.asType(h.dtype)
-        }
-
-        var newCache = [(MLXArray, MLXArray)]()
+        let mask: MLXArray? = createAttentionMask(h: h, cache: cache)
 
         for (i, layer) in layers.enumerated() {
-            var cacheUpdate: (MLXArray, MLXArray)
-            (h, cacheUpdate) = layer(h, mask: mask, cache: cache?[i])
-            newCache.append(cacheUpdate)
+            h = layer(h, mask: mask, cache: cache?[i])
         }
 
-        return (norm(h), newCache)
+        return norm(h)
     }
 }
 
-public class Starcoder2Model: Module, LLMModel {
-    public var vocabularySize: Int
+public class Starcoder2Model: Module, LLMModel, KVCacheDimensionProvider {
+    public let vocabularySize: Int
+    public let kvHeads: [Int]
+    public let headDim: IntOrPair
 
     public let tieWordEmbeddings: Bool
     let model: Starcoder2ModelInner
@@ -168,6 +159,8 @@ public class Starcoder2Model: Module, LLMModel {
 
     public init(_ args: Starcoder2Configuration) {
         self.vocabularySize = args.vocabularySize
+        self.kvHeads = (0 ..< args.hiddenLayers).map { _ in args.kvHeads }
+        self.headDim = .init(args.hiddenSize / args.attentionHeads)
         self.model = Starcoder2ModelInner(args)
         self.tieWordEmbeddings = args.tieWordEmbeddings
         if !self.tieWordEmbeddings {
@@ -175,16 +168,14 @@ public class Starcoder2Model: Module, LLMModel {
         }
     }
 
-    public func callAsFunction(_ inputs: MLXArray, cache: [(MLXArray, MLXArray)]?) -> (
-        MLXArray, [(MLXArray, MLXArray)]
-    ) {
-        var (out, cache) = model(inputs, cache: cache)
+    public func callAsFunction(_ inputs: MLXArray, cache: [KVCache]?) -> MLXArray {
+        var out = model(inputs, cache: cache)
 
         if !tieWordEmbeddings {
-            return (lmHead(out), cache)
+            return lmHead(out)
         } else {
             out = matmul(out, model.embedTokens.weight.T)
-            return (out, cache)
+            return out
         }
     }
 }

--- a/Libraries/LLM/Tokenizer.swift
+++ b/Libraries/LLM/Tokenizer.swift
@@ -77,7 +77,7 @@ public struct NaiveStreamingDetokenizer: StreamingDetokenizer {
         let newSegment = tokenizer.decode(tokens: segmentTokens)
         let new = newSegment.suffix(newSegment.count - segment.count)
 
-        if new.contains("\n") {
+        if new.hasSuffix("\n") {
             startNewSegment()
         } else {
             self.segment = newSegment

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
             targets: ["MLXMNIST"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/ml-explore/mlx-swift", from: "0.16.0"),
+        .package(url: "https://github.com/ml-explore/mlx-swift", from: "0.16.1"),
         .package(url: "https://github.com/huggingface/swift-transformers", from: "0.1.9"),
         .package(url: "https://github.com/1024jp/GzipSwift", "6.0.1" ... "6.0.1"),
         .package(url: "https://github.com/apple/swift-async-algorithms", from: "1.0.0"),

--- a/mlx-swift-examples.xcodeproj/project.pbxproj
+++ b/mlx-swift-examples.xcodeproj/project.pbxproj
@@ -40,6 +40,7 @@
 		C36BEFB52BBDEAD8002D4AFE /* LoraCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = C36BEFB32BBDEA69002D4AFE /* LoraCommands.swift */; };
 		C36BEFB82BBDED51002D4AFE /* Arguments.swift in Sources */ = {isa = PBXBuildFile; fileRef = C36BEFB62BBDECBC002D4AFE /* Arguments.swift */; };
 		C36BEFBB2BBF02CC002D4AFE /* Lora+Data.swift in Sources */ = {isa = PBXBuildFile; fileRef = C36BEFBA2BBF02CC002D4AFE /* Lora+Data.swift */; };
+		C373EB732C792DD1004E201E /* KVCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = C373EB722C792DD1004E201E /* KVCache.swift */; };
 		C38935C82B869C7A0037B833 /* LLM.h in Headers */ = {isa = PBXBuildFile; fileRef = C38935C72B869C7A0037B833 /* LLM.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C38935CC2B869C870037B833 /* Llama.swift in Sources */ = {isa = PBXBuildFile; fileRef = C34E48EE2B696E6500FCB841 /* Llama.swift */; };
 		C38935CD2B869C870037B833 /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = C34E48EF2B696E6500FCB841 /* Configuration.swift */; };
@@ -255,6 +256,7 @@
 		C36BEFB32BBDEA69002D4AFE /* LoraCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoraCommands.swift; sourceTree = "<group>"; };
 		C36BEFB62BBDECBC002D4AFE /* Arguments.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Arguments.swift; sourceTree = "<group>"; };
 		C36BEFBA2BBF02CC002D4AFE /* Lora+Data.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Lora+Data.swift"; sourceTree = "<group>"; };
+		C373EB722C792DD1004E201E /* KVCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KVCache.swift; sourceTree = "<group>"; };
 		C38935C52B869C7A0037B833 /* LLM.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = LLM.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C38935C72B869C7A0037B833 /* LLM.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LLM.h; sourceTree = "<group>"; };
 		C38935DE2B869DD00037B833 /* Phi.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Phi.swift; sourceTree = "<group>"; };
@@ -488,6 +490,7 @@
 				C34E48F62B69832600FCB841 /* README.md */,
 				C34E48ED2B696E6500FCB841 /* Load.swift */,
 				C3E786AA2B8D1AEC0004D037 /* Evaluate.swift */,
+				C373EB722C792DD1004E201E /* KVCache.swift */,
 				C3E786AC2B8D4AF50004D037 /* Tokenizer.swift */,
 				52A776172B94B5EE00AA6E80 /* Qwen2.swift */,
 				F24B08392BAF1A65008C8D19 /* Cohere.swift */,
@@ -1003,6 +1006,7 @@
 				C38935E12B869F420037B833 /* LLMModel.swift in Sources */,
 				F24B083A2BAF1A65008C8D19 /* Cohere.swift in Sources */,
 				C38935E32B86C0FE0037B833 /* Gemma.swift in Sources */,
+				C373EB732C792DD1004E201E /* KVCache.swift in Sources */,
 				C38935CD2B869C870037B833 /* Configuration.swift in Sources */,
 				1CD79C702BD80DE100B6C06F /* Phi3.swift in Sources */,
 				525C1E9D2B9A011000B5C356 /* Starcoder2.swift in Sources */,
@@ -2708,7 +2712,7 @@
 			repositoryURL = "https://github.com/ml-explore/mlx-swift";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 0.16.0;
+				minimumVersion = 0.16.1;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/mlx-swift-examples.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/mlx-swift-examples.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ml-explore/mlx-swift",
       "state" : {
-        "revision" : "597aaa5f465b4b9a17c8646b751053f84e37925b",
-        "version" : "0.16.0"
+        "revision" : "86ad75ab1ee96cd70325732b37cd830f87d7e43f",
+        "version" : "0.16.1"
       }
     },
     {


### PR DESCRIPTION
- sampling code compiled
- KVCache
- async_eval
- NaiveStreamingDetokenizer

My starting point with mlx v0.16.0:

```
./mlx-run llm-tool --model mlx-community/Phi-3-mini-4k-instruct-4bit -m 100000 --temperature 0 -p @/tmp/p.txt --cache-size 500 --temperature 0
```

Prompt is:

```
<|system|>
You are a helpful assistant.<|end|>
<|user|>
How to explain Internet for a medieval knight?<|end|>
<|assistant|>
```

Here are the initial performance numbers:

```
python Generation: 673 tokens, 114.404 tokens-per-sec, 5.873911874999999s
swift Generation: 673 tokens, 83.136954 tokens/s
```

Looking at the profiler we can see:

| Task | Python | Swift |
| --- | --- | --- |
| Wall Time | 9.6 | 12.1 |
| CPU Time | 10.94 | 9.91 |
| Metal Submit | 1.75 | 3.83 |
| Metal didComplete | 0.48 | 0.83 |
| mlx::core:scheduler | 2.92 | 3.63 |
| blas_thread_server | 2.9 | - |
| main | 1.67 | 0.74 |

I am not sure what the `blas_thread_server` is, but it is soaking up a bunch of CPU time — it looks like it is running async to the main computation, so other than efficiency isn’t affecting performance.  If we subtract the blas_thread_server from the CPU time it is clear the python code is doing less work.

I found the following:

- The sampling code in python is compiled — this made a pretty big difference
- The KVCache also made a big difference
- The async_eval in the python code helped a little
- The NaiveStreamingDetokenizer helped a little

The prompt splitting didn’t help here as the default split size is 512 and that is larger than the prompt.  The output in this case is only 673 tokens, so I don’t think that is particularly long, so some of these may not be getting the full benefit.

With these in place the performance is getting closer:

```
python Generation: 673 tokens, 114.404 tokens-per-sec, 5.873911874999999s
swift 673 tokens, 97.718867 tokens/s, 6.887104s
```

| Task | Python | Swift |
| --- | --- | --- |
| Wall Time | 9.6 | 9.4 |
| CPU Time | 10.94 | 7.6 |
| Metal Submit | 1.75 | 1.21 |
| Metal didComplete | 0.48 | 0.28 |
| mlx::core:scheduler | 2.92 | 1.99 |
| blas_thread_server | 2.9 | - |
| main | 1.67 | 0.69 |

We have a big win in CPU time and even total wall time (startup time I presume) but are still nearly a second slower on the generation, so there is still some more work needed.

# Part 2!

Here is the output from swift -- for comparison I had 114 tokens/s from python (though it was usually lower than that and I found the number to be noisy). 

```
Prompt:     21 tokens, 212.221945 tokens/s
Generation: 673 tokens, 114.662957 tokens/s, 5.869376s
```

Here is output from Instruments showing the synchronous evaluation (via `item()`), the `async_eval()` calls and the GPU activity in the python program:

<img width="1221" alt="image" src="https://github.com/user-attachments/assets/41eaccce-6591-4a58-8db7-cc6a3ce96a49">

Notice that the GPU stays active most of the time.

Here is a similar view of the swift program (at around 97 tokens/s) from part 1:

<img width="1222" alt="image" src="https://github.com/user-attachments/assets/0add6f4a-0dbe-4bbf-8432-72d29e62974a">

The pattern is similar, but there are ~1.5ms gaps where the GPU goes idle -- the scheduler didn't have any work to do.

The final version looks like this:

<img width="1214" alt="image" src="https://github.com/user-attachments/assets/19d0da35-2a09-4409-b780-b4e08fa30960">

The GPU is kept busy and we are hitting our performance targets!

The final changes resolved an issue with the `asyncEval()` and `item()`/`eval()` calls that were causing `item()` to wait for the completion of the `asyncEval()` -- see https://github.com/ml-explore/mlx-swift/pull/127.