### PR TITLE
tokenizer load must come before model load

### DIFF
--- a/Libraries/LLM/LLMModel.swift
+++ b/Libraries/LLM/LLMModel.swift
@@ -42,12 +42,14 @@ public actor ModelContainer {
     public init(
         hub: HubApi, modelDirectory: URL, configuration: ModelConfiguration
     ) async throws {
-        self.model = try loadSynchronous(modelDirectory: modelDirectory)
-
+        // Note: a side effect of loading the tokenizer is that it will ensure
+        // the config.json is downloaded, which is required by the model loading below
         let (tokenizerConfig, tokenizerData) = try await loadTokenizerConfig(
             configuration: configuration, hub: hub)
         self.tokenizer = try PreTrainedTokenizer(
             tokenizerConfig: tokenizerConfig, tokenizerData: tokenizerData)
+
+        self.model = try loadSynchronous(modelDirectory: modelDirectory)
     }
 
     /// Perform an action on the model and/or tokenizer.  Callers _must_ eval any `MLXArray` before returning as

--- a/Libraries/LLM/Load.swift
+++ b/Libraries/LLM/Load.swift
@@ -41,8 +41,12 @@ public func load(
 ) async throws -> (LLMModel, Tokenizer) {
     let modelDirectory = try await prepareModelDirectory(
         hub: hub, configuration: configuration, progressHandler: progressHandler)
-    let model = try loadSynchronous(modelDirectory: modelDirectory)
+
+    // Note: a side effect of loading the tokenizer is that it will ensure
+    // the config.json is downloaded, which is required by the model loading
     let tokenizer = try await loadTokenizer(configuration: configuration, hub: hub)
+
+    let model = try loadSynchronous(modelDirectory: modelDirectory)
 
     return (model, tokenizer)
 }


### PR DESCRIPTION
- the tokenizer load makes sure the config.json is downloaded (LanguageModelConfigurationFromHub)
- this is also used by the model loading (it has the configuration for the model)
- this has to be run before the model weights are loaded for new downloads