### PR TITLE
implement stable diffusion example

### DIFF
--- a/Applications/StableDiffusionExample/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/Applications/StableDiffusionExample/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Applications/StableDiffusionExample/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Applications/StableDiffusionExample/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,63 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "16x16"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "16x16"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "32x32"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "32x32"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "128x128"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "128x128"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "256x256"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "256x256"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "512x512"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "512x512"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Applications/StableDiffusionExample/Assets.xcassets/Contents.json
+++ b/Applications/StableDiffusionExample/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Applications/StableDiffusionExample/ContentView.swift
+++ b/Applications/StableDiffusionExample/ContentView.swift
@@ -158,7 +158,7 @@ actor ModelFactory {
                 let container = try ModelContainer<TextToImageGenerator>.createTextToImageGenerator(
                     configuration: configuration, loadConfiguration: loadConfiguration)
 
-                await container.setConservativeMemory(conserveMemory)
+                await container.setConserveMemory(conserveMemory)
 
                 try await container.perform { model in
                     reportProgress(.init(title: "Loading weights", current: 0, limit: 1))

--- a/Applications/StableDiffusionExample/ContentView.swift
+++ b/Applications/StableDiffusionExample/ContentView.swift
@@ -1,0 +1,310 @@
+// Copyright © 2024 Apple Inc.
+
+import MLX
+import StableDiffusion
+import SwiftUI
+
+struct ContentView: View {
+
+    @State var prompt = "dismal swamp, dense, very dark, realistic"
+    @State var negativePrompt = ""
+    @State var evaluator = StableDiffusionEvaluator()
+    @State var showProgress = false
+
+    var body: some View {
+        VStack {
+            HStack {
+                if let progress = evaluator.progress {
+                    ProgressView(progress.title, value: progress.current, total: progress.limit)
+                }
+            }
+            .frame(height: 20)
+
+            Spacer()
+            if let image = evaluator.image {
+                Image(image, scale: 1.0, label: Text(""))
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(minHeight: 200)
+            }
+            Spacer()
+
+            Grid {
+                GridRow {
+                    TextField("prompt", text: $prompt)
+                        .onSubmit(generate)
+                        .disabled(evaluator.progress != nil)
+                        #if os(visionOS)
+                            .textFieldStyle(.roundedBorder)
+                        #endif
+
+                    Button(action: { prompt = "" }) {
+                        Label("clear", systemImage: "xmark.circle.fill").font(.system(size: 10))
+                    }
+                    .labelStyle(.iconOnly)
+                    .buttonStyle(.plain)
+
+                    Button("generate", action: generate)
+                        .disabled(evaluator.progress != nil)
+                        .keyboardShortcut("r")
+                }
+                if evaluator.modelFactory.canShowProgress
+                    || evaluator.modelFactory.canUseNegativeText
+                {
+                    GridRow {
+                        if evaluator.modelFactory.canUseNegativeText {
+                            TextField("negative prompt", text: $negativePrompt)
+                                .onSubmit(generate)
+                                .disabled(evaluator.progress != nil)
+                                #if os(visionOS)
+                                    .textFieldStyle(.roundedBorder)
+                                #endif
+                            Button(action: { prompt = "" }) {
+                                Label("clear", systemImage: "xmark.circle.fill").font(
+                                    .system(size: 10))
+                            }
+                            .labelStyle(.iconOnly)
+                            .buttonStyle(.plain)
+                        } else {
+                            EmptyView()
+                            EmptyView()
+                        }
+
+                        if evaluator.modelFactory.canShowProgress {
+                            Toggle("Show Progress", isOn: $showProgress)
+                        }
+                    }
+                }
+            }
+            .frame(minWidth: 300)
+        }
+        .padding()
+    }
+
+    private func generate() {
+        Task {
+            await evaluator.generate(
+                prompt: prompt, negativePrompt: negativePrompt, showProgress: showProgress)
+        }
+    }
+}
+
+/// Progress reporting with a title.
+struct Progress: Equatable {
+    let title: String
+    let current: Double
+    let limit: Double
+}
+
+/// Async model factory
+actor ModelFactory {
+
+    enum LoadState {
+        case idle
+        case loading(Task<ModelContainer<TextToImageGenerator>, Error>)
+        case loaded(ModelContainer<TextToImageGenerator>)
+    }
+
+    enum SDError: Error {
+        case unableToLoad
+    }
+
+    public nonisolated let configuration = StableDiffusionConfiguration.presetSDXLTurbo
+
+    /// if true we show UI that lets users see the intermediate steps
+    public nonisolated let canShowProgress: Bool
+
+    /// if true we show UI to give negative text
+    public nonisolated let canUseNegativeText: Bool
+
+    private var loadState = LoadState.idle
+    private var loadConfiguration = LoadConfiguration(float16: true, quantize: false)
+
+    public nonisolated let conserveMemory: Bool
+
+    init() {
+        let defaultParameters = configuration.defaultParameters()
+        self.canShowProgress = defaultParameters.steps > 4
+        self.canUseNegativeText = defaultParameters.cfgWeight > 1
+
+        // this will be true e.g. if the computer has 8G of memory or less
+        self.conserveMemory = MLX.GPU.memoryLimit < 8 * 1024 * 1024 * 1024
+
+        if conserveMemory {
+            print("conserving memory")
+            loadConfiguration.quantize = true
+            MLX.GPU.set(cacheLimit: 1 * 1024 * 1024)
+            MLX.GPU.set(memoryLimit: 3 * 1024 * 1024 * 1024)
+        } else {
+            MLX.GPU.set(cacheLimit: 256 * 1024 * 1024)
+        }
+    }
+
+    public func load(reportProgress: @escaping @Sendable (Progress) -> Void) async throws
+        -> ModelContainer<TextToImageGenerator>
+    {
+        switch loadState {
+        case .idle:
+            let task = Task {
+                try await configuration.download { progress in
+                    if progress.fractionCompleted < 0.99 {
+                        reportProgress(
+                            .init(
+                                title: "Download", current: progress.fractionCompleted * 100,
+                                limit: 100))
+                    }
+                }
+
+                let container = try ModelContainer<TextToImageGenerator>.createTextToImageGenerator(
+                    configuration: configuration, loadConfiguration: loadConfiguration)
+
+                await container.setConservativeMemory(conserveMemory)
+
+                try await container.perform { model in
+                    reportProgress(.init(title: "Loading weights", current: 0, limit: 1))
+                    if !conserveMemory {
+                        model.ensureLoaded()
+                    }
+                }
+
+                return container
+            }
+            self.loadState = .loading(task)
+
+            let container = try await task.value
+
+            if conserveMemory {
+                // if conserving memory return the model but do not keep it in memory
+                self.loadState = .idle
+            } else {
+                // cache the model in memory to make it faster to run with new prompts
+                self.loadState = .loaded(container)
+            }
+
+            return container
+
+        case .loading(let task):
+            let generator = try await task.value
+            return generator
+
+        case .loaded(let generator):
+            return generator
+        }
+    }
+
+}
+
+@Observable @MainActor
+class StableDiffusionEvaluator {
+
+    var progress: Progress?
+    var message: String?
+    var image: CGImage?
+
+    let modelFactory = ModelFactory()
+
+    @Sendable
+    nonisolated private func updateProgress(progress: Progress?) {
+        Task { @MainActor in
+            self.progress = progress
+        }
+    }
+
+    @Sendable
+    nonisolated private func updateImage(image: CGImage?) {
+        Task { @MainActor in
+            self.image = image
+        }
+    }
+
+    nonisolated private func display(decoded: MLXArray) {
+        let raster = (decoded * 255).asType(.uint8).squeezed()
+        let image = Image(raster).asCGImage()
+
+        Task { @MainActor in
+            updateImage(image: image)
+        }
+    }
+
+    func generate(prompt: String, negativePrompt: String, showProgress: Bool) async {
+        progress = .init(title: "Preparing", current: 0, limit: 1)
+        message = nil
+
+        // the parameters that control the generation of the image.  See
+        // EvaluateParameters for more information.  For example adjusting
+        // the latentSize parameter will change the size of the generated
+        // image.  imageCount could be used to generate a gallery of
+        // images at the same time.
+        let parameters = {
+            var p = modelFactory.configuration.defaultParameters()
+            p.prompt = prompt
+            p.negativePrompt = negativePrompt
+
+            // per measurement each step consumes memory that we want to conserve.  trade
+            // off steps (quality) for memory
+            if modelFactory.conserveMemory {
+                p.steps = 1
+            }
+
+            return p
+        }()
+
+        do {
+            // note: the optionals are used to discard parts of the model
+            // as it runs -- this is used to conserveMemory in devices
+            // with less memory
+            let container = try await modelFactory.load(reportProgress: updateProgress)
+
+            try await container.performTwoStage { generator in
+                // the parameters that control the generation of the image.  See
+                // EvaluateParameters for more information.  For example adjusting
+                // the latentSize parameter will change the size of the generated
+                // image.  imageCount could be used to generate a gallery of
+                // images at the same time.
+                var parameters = modelFactory.configuration.defaultParameters()
+                parameters.prompt = prompt
+                parameters.negativePrompt = negativePrompt
+
+                // per measurement each step consumes memory that we want to conserve.  trade
+                // off steps (quality) for memory
+                if modelFactory.conserveMemory {
+                    parameters.steps = 1
+                }
+
+                // generate the latent images -- this is fast as it is just generating
+                // the graphs that will be evaluated below
+                let latents: DenoiseIterator? = generator.generateLatents(parameters: parameters)
+
+                // when conserveMemory is true this will discard the first part of
+                // the model and just evaluate the decode portion
+                return (generator.detachedDecoder(), latents)
+
+            } second: { decoder, latents in
+                var lastXt: MLXArray?
+                for (i, xt) in latents!.enumerated() {
+                    lastXt = nil
+                    eval(xt)
+                    lastXt = xt
+
+                    if showProgress, i % 10 == 0 {
+                        display(decoded: decoder(xt))
+                    }
+
+                    updateProgress(
+                        progress: .init(
+                            title: "Generate Latents", current: Double(i),
+                            limit: Double(parameters.steps)))
+                }
+
+                if let lastXt {
+                    display(decoded: decoder(lastXt))
+                }
+                updateProgress(progress: nil)
+            }
+
+        } catch {
+            progress = nil
+            message = "Failed: \(error)"
+        }
+    }
+}

--- a/Applications/StableDiffusionExample/Preview Content/Preview Assets.xcassets/Contents.json
+++ b/Applications/StableDiffusionExample/Preview Content/Preview Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Applications/StableDiffusionExample/README.md
+++ b/Applications/StableDiffusionExample/README.md
@@ -1,0 +1,33 @@
+#  StableDiffusionExample
+
+An example application that runs the StableDiffusion example code.
+
+See also [image-tool](../../Tools/image-tool) for a command line example.
+
+This example application accepts a prompt and used the StableDiffusion example
+library to render an image using:
+
+- [stabilityai/sdxl-turbo](https://huggingface.co/stabilityai/sdxl-turbo)
+
+Please refer to that model for license and other information.
+
+If you are interested in adjusting the generated images, look in 
+[ContentView.swift](ContentView.swift) at this method:
+
+```swift
+    func generate(prompt: String, negativePrompt: String, showProgress: Bool) async 
+```
+
+### Troubleshooting
+
+Stable diffusion can run in less that 4G available memory (typically a
+device or computer with 6G of memory or more) in a constrained mode -- it will
+load and unload parts of the model as it runs and it can only perform one step
+of diffusion.  This is configured automatically, see `modelFactory.conserveMemory`
+in [ContentView.swift](ContentView.swift).
+
+On a device or computer with more memory the model will be kept resident and
+images can be regenerated much more efficiently.
+
+If the program exits while generating the image it may have exceeded the available
+memory.

--- a/Applications/StableDiffusionExample/StableDiffusionExample.entitlements
+++ b/Applications/StableDiffusionExample/StableDiffusionExample.entitlements
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.kernel.increased-memory-limit</key>
+	<true/>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.files.user-selected.read-only</key>
+	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
+</dict>
+</plist>

--- a/Applications/StableDiffusionExample/StableDiffusionExampleApp.swift
+++ b/Applications/StableDiffusionExample/StableDiffusionExampleApp.swift
@@ -1,0 +1,12 @@
+// Copyright © 2024 Apple Inc.
+
+import SwiftUI
+
+@main
+struct StableDiffusionExampleApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/Libraries/StableDiffusion/Clip.swift
+++ b/Libraries/StableDiffusion/Clip.swift
@@ -1,0 +1,136 @@
+// Copyright © 2024 Apple Inc.
+
+import Foundation
+import MLX
+import MLXNN
+
+// port of https://github.com/ml-explore/mlx-examples/blob/main/stable_diffusion/stable_diffusion/clip.py
+
+struct CLIPOutput {
+    /// The lastHiddenState indexed at the EOS token and possibly projected if
+    /// the model has a projection layer
+    public var pooledOutput: MLXArray
+
+    /// The full sequence output of the transformer after the final layernorm
+    public var lastHiddenState: MLXArray
+
+    /// A list of hidden states corresponding to the outputs of the transformer layers
+    public var hiddenStates: [MLXArray]
+}
+
+/// The transformer encoder layer from CLIP
+class CLIPEncoderLayer: Module {
+
+    @ModuleInfo(key: "layer_norm1") var layerNorm1: LayerNorm
+    @ModuleInfo(key: "layer_norm2") var layerNorm2: LayerNorm
+
+    let attention: MultiHeadAttention
+
+    @ModuleInfo var linear1: Linear
+    @ModuleInfo var linear2: Linear
+
+    let activation: (MLXArray) -> MLXArray
+
+    init(modelDimensions: Int, numHeads: Int, activation: @escaping (MLXArray) -> MLXArray) {
+        self._layerNorm1.wrappedValue = LayerNorm(dimensions: modelDimensions)
+        self._layerNorm2.wrappedValue = LayerNorm(dimensions: modelDimensions)
+
+        self.attention = MultiHeadAttention(
+            dimensions: modelDimensions, numHeads: numHeads, bias: true)
+
+        self.linear1 = Linear(modelDimensions, 4 * modelDimensions)
+        self.linear2 = Linear(4 * modelDimensions, modelDimensions)
+
+        self.activation = activation
+    }
+
+    func callAsFunction(_ x: MLXArray, attentionMask: MLXArray? = nil) -> MLXArray {
+        var y = layerNorm1(x)
+        y = attention(y, keys: y, values: y, mask: attentionMask)
+        var x = y + x
+
+        y = layerNorm2(x)
+        y = linear1(y)
+        y = activation(y)
+        y = linear2(y)
+        x = y + x
+
+        return x
+    }
+}
+
+/// Implements the text encoder transformer from CLIP
+class CLIPTextModel: Module {
+
+    @ModuleInfo(key: "token_embedding") var tokenEmbedding: Embedding
+    @ModuleInfo(key: "position_embedding") var positionEmbedding: Embedding
+
+    let layers: [CLIPEncoderLayer]
+
+    @ModuleInfo(key: "final_layer_norm") var finalLayerNorm: LayerNorm
+
+    @ModuleInfo(key: "text_projection") var textProjection: Linear?
+
+    init(configuration: CLIPTextModelConfiguration) {
+        self._tokenEmbedding.wrappedValue = Embedding(
+            embeddingCount: configuration.vocabularySize, dimensions: configuration.modelDimensions)
+        self._positionEmbedding.wrappedValue = Embedding(
+            embeddingCount: configuration.maxLength, dimensions: configuration.modelDimensions)
+
+        self.layers = (0 ..< configuration.numLayers)
+            .map { _ in
+                CLIPEncoderLayer(
+                    modelDimensions: configuration.modelDimensions,
+                    numHeads: configuration.numHeads,
+                    activation: configuration.hiddenActivation.activation)
+            }
+
+        self._finalLayerNorm.wrappedValue = LayerNorm(dimensions: configuration.modelDimensions)
+
+        if let projectionDimensions = configuration.projectionDimensions {
+            self._textProjection.wrappedValue = Linear(
+                configuration.modelDimensions, projectionDimensions, bias: false)
+        } else {
+            self._textProjection.wrappedValue = nil
+        }
+    }
+
+    func mask(_ N: Int, _ dType: DType) -> MLXArray {
+        let indices = MLXArray(0 ..< Int32(N))
+        var mask = indices[0..., .newAxis] .< indices[.newAxis]
+        mask = mask.asType(dType) * (dType == .float16 ? -6e4 : -1e9)
+        return mask
+    }
+
+    func callAsFunction(_ x: MLXArray) -> CLIPOutput {
+        var x = x
+        let (_, N) = x.shape2
+        let eosTokens = x.argMax(axis: -1)
+
+        // compute the embeddings
+        x = tokenEmbedding(x)
+        x = x + positionEmbedding.weight[..<N]
+
+        // compute the features from the transformer
+        let mask = mask(N, x.dtype)
+        var hiddenStates = [MLXArray]()
+        for l in layers {
+            x = l(x, attentionMask: mask)
+            hiddenStates.append(x)
+        }
+
+        // apply the final layernorm
+        x = finalLayerNorm(x)
+        let lastHiddenState = x
+
+        // select the EOS token
+        var pooledOutput = x[MLXArray(0 ..< x.count), eosTokens]
+        if let textProjection {
+            pooledOutput = textProjection(pooledOutput)
+        }
+
+        return CLIPOutput(
+            pooledOutput: pooledOutput, lastHiddenState: lastHiddenState, hiddenStates: hiddenStates
+        )
+    }
+}

--- a/Libraries/StableDiffusion/Configuration.swift
+++ b/Libraries/StableDiffusion/Configuration.swift
@@ -1,0 +1,271 @@
+// Copyright © 2024 Apple Inc.
+
+import Foundation
+import MLX
+import MLXNN
+
+// port of https://github.com/ml-explore/mlx-examples/blob/main/stable_diffusion/stable_diffusion/config.py
+
+/// Configuration for ``Autoencoder``
+struct AutoencoderConfiguration: Codable {
+
+    public var inputChannels = 3
+    public var outputChannels = 3
+    public var latentChannelsOut: Int { latentChannelsIn * 2 }
+    public var latentChannelsIn = 4
+    public var blockOutChannels = [128, 256, 512, 512]
+    public var layersPerBlock = 2
+    public var normNumGroups = 32
+    public var scalingFactor: Float = 0.18215
+
+    enum CodingKeys: String, CodingKey {
+        case inputChannels = "in_channels"
+        case outputChannels = "out_channels"
+        case latentChannelsIn = "latent_channels"
+        case blockOutChannels = "block_out_channels"
+        case layersPerBlock = "layers_per_block"
+        case normNumGroups = "norm_num_groups"
+        case scalingFactor = "scaling_factor"
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container: KeyedDecodingContainer<AutoencoderConfiguration.CodingKeys> =
+            try decoder.container(keyedBy: AutoencoderConfiguration.CodingKeys.self)
+
+        // load_autoencoder()
+
+        self.scalingFactor =
+            try container.decodeIfPresent(Float.self, forKey: .scalingFactor) ?? 0.18215
+
+        self.inputChannels = try container.decode(Int.self, forKey: .inputChannels)
+        self.outputChannels = try container.decode(Int.self, forKey: .outputChannels)
+        self.latentChannelsIn = try container.decode(Int.self, forKey: .latentChannelsIn)
+        self.blockOutChannels = try container.decode([Int].self, forKey: .blockOutChannels)
+        self.layersPerBlock = try container.decode(Int.self, forKey: .layersPerBlock)
+        self.normNumGroups = try container.decode(Int.self, forKey: .normNumGroups)
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var container: KeyedEncodingContainer<AutoencoderConfiguration.CodingKeys> =
+            encoder.container(keyedBy: AutoencoderConfiguration.CodingKeys.self)
+
+        try container.encode(self.inputChannels, forKey: .inputChannels)
+        try container.encode(self.outputChannels, forKey: .outputChannels)
+        try container.encode(self.latentChannelsIn, forKey: .latentChannelsIn)
+        try container.encode(self.blockOutChannels, forKey: .blockOutChannels)
+        try container.encode(self.layersPerBlock, forKey: .layersPerBlock)
+        try container.encode(self.normNumGroups, forKey: .normNumGroups)
+        try container.encode(self.scalingFactor, forKey: .scalingFactor)
+    }
+}
+
+/// Configuration for ``CLIPTextModel``
+struct CLIPTextModelConfiguration: Codable {
+
+    public enum ClipActivation: String, Codable {
+        case fast = "quick_gelu"
+        case gelu = "gelu"
+
+        var activation: (MLXArray) -> MLXArray {
+            switch self {
+            case .fast: MLXNN.geluFastApproximate
+            case .gelu: MLXNN.gelu
+            }
+        }
+    }
+
+    public var numLayers = 23
+    public var modelDimensions = 1024
+    public var numHeads = 16
+    public var maxLength = 77
+    public var vocabularySize = 49408
+    public var projectionDimensions: Int? = nil
+    public var hiddenActivation: ClipActivation = .fast
+
+    enum CodingKeys: String, CodingKey {
+        case numLayers = "num_hidden_layers"
+        case modelDimensions = "hidden_size"
+        case numHeads = "num_attention_heads"
+        case maxLength = "max_position_embeddings"
+        case vocabularySize = "vocab_size"
+        case projectionDimensions = "projection_dim"
+        case hiddenActivation = "hidden_act"
+        case architectures = "architectures"
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container: KeyedDecodingContainer<CLIPTextModelConfiguration.CodingKeys> =
+            try decoder.container(keyedBy: CLIPTextModelConfiguration.CodingKeys.self)
+
+        // see load_text_encoder
+
+        let architectures = try container.decode([String].self, forKey: .architectures)
+        let withProjection = architectures[0].contains("WithProjection")
+
+        self.projectionDimensions =
+            withProjection
+            ? try container.decodeIfPresent(Int.self, forKey: .projectionDimensions) : nil
+        self.hiddenActivation =
+            try container.decodeIfPresent(
+                CLIPTextModelConfiguration.ClipActivation.self, forKey: .hiddenActivation) ?? .fast
+
+        self.numLayers = try container.decode(Int.self, forKey: .numLayers)
+        self.modelDimensions = try container.decode(Int.self, forKey: .modelDimensions)
+        self.numHeads = try container.decode(Int.self, forKey: .numHeads)
+        self.maxLength = try container.decode(Int.self, forKey: .maxLength)
+        self.vocabularySize = try container.decode(Int.self, forKey: .vocabularySize)
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var container: KeyedEncodingContainer<CLIPTextModelConfiguration.CodingKeys> =
+            encoder.container(keyedBy: CLIPTextModelConfiguration.CodingKeys.self)
+
+        if projectionDimensions != nil {
+            try container.encode(["WithProjection"], forKey: .architectures)
+        } else {
+            try container.encode(["Other"], forKey: .architectures)
+        }
+
+        try container.encode(self.numLayers, forKey: .numLayers)
+        try container.encode(self.modelDimensions, forKey: .modelDimensions)
+        try container.encode(self.numHeads, forKey: .numHeads)
+        try container.encode(self.maxLength, forKey: .maxLength)
+        try container.encode(self.vocabularySize, forKey: .vocabularySize)
+        try container.encodeIfPresent(self.projectionDimensions, forKey: .projectionDimensions)
+        try container.encode(self.hiddenActivation, forKey: .hiddenActivation)
+    }
+}
+
+/// Configuration for ``UNetModel``
+struct UNetConfiguration: Codable {
+
+    public var inputChannels = 4
+    public var outputChannels = 4
+    public var convolutionInKernel = 3
+    public var convolutionOutKernel = 3
+    public var blockOutChannels = [320, 640, 1280, 1280]
+    public var layersPerBlock = [2, 2, 2, 2]
+    public var midBlockLayers = 2
+    public var transformerLayersPerBlock = [2, 2, 2, 2]
+    public var numHeads = [5, 10, 20, 20]
+    public var crossAttentionDimension = [1024, 1024, 1024, 1024]
+    public var normNumGroups = 32
+    public var downBlockTypes: [String] = []
+    public var upBlockTypes: [String] = []
+    public var additionEmbedType: String? = nil
+    public var additionTimeEmbedDimension: Int? = nil
+    public var projectionClassEmbeddingsInputDimension: Int? = nil
+
+    enum CodingKeys: String, CodingKey {
+        case inputChannels = "in_channels"
+        case outputChannels = "out_channels"
+        case convolutionInKernel = "conv_in_kernel"
+        case convolutionOutKernel = "conv_out_kernel"
+        case blockOutChannels = "block_out_channels"
+        case layersPerBlock = "layers_per_block"
+        case midBlockLayers = "mid_block_layers"
+        case transformerLayersPerBlock = "transformer_layers_per_block"
+        case numHeads = "attention_head_dim"
+        case crossAttentionDimension = "cross_attention_dim"
+        case normNumGroups = "norm_num_groups"
+        case downBlockTypes = "down_block_types"
+        case upBlockTypes = "up_block_types"
+        case additionEmbedType = "addition_embed_type"
+        case additionTimeEmbedDimension = "addition_time_embed_dim"
+        case projectionClassEmbeddingsInputDimension = "projection_class_embeddings_input_dim"
+    }
+
+    public init() {
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container: KeyedDecodingContainer<UNetConfiguration.CodingKeys> = try decoder.container(
+            keyedBy: UNetConfiguration.CodingKeys.self)
+
+        // customizations based on def load_unet(key: str = _DEFAULT_MODEL, float16: bool = False):
+        //
+        // Note: the encode() writes out the internal format (and this can load it back in)
+
+        self.blockOutChannels = try container.decode([Int].self, forKey: .blockOutChannels)
+        let nBlocks = blockOutChannels.count
+
+        self.layersPerBlock =
+            try (try? container.decode([Int].self, forKey: .layersPerBlock))
+            ?? Array(repeating: container.decode(Int.self, forKey: .layersPerBlock), count: nBlocks)
+        self.transformerLayersPerBlock =
+            (try? container.decode([Int].self, forKey: .transformerLayersPerBlock)) ?? [1, 1, 1, 1]
+        self.numHeads =
+            try (try? container.decodeIfPresent([Int].self, forKey: .numHeads))
+            ?? Array(repeating: container.decode(Int.self, forKey: .numHeads), count: nBlocks)
+        self.crossAttentionDimension =
+            try (try? container.decode([Int].self, forKey: .crossAttentionDimension))
+            ?? Array(
+                repeating: container.decode(Int.self, forKey: .crossAttentionDimension),
+                count: nBlocks)
+        self.upBlockTypes = try container.decode([String].self, forKey: .upBlockTypes).reversed()
+
+        self.convolutionInKernel =
+            try container.decodeIfPresent(Int.self, forKey: .convolutionInKernel) ?? 3
+        self.convolutionOutKernel =
+            try container.decodeIfPresent(Int.self, forKey: .convolutionOutKernel) ?? 3
+        self.midBlockLayers = try container.decodeIfPresent(Int.self, forKey: .midBlockLayers) ?? 2
+
+        self.inputChannels = try container.decode(Int.self, forKey: .inputChannels)
+        self.outputChannels = try container.decode(Int.self, forKey: .outputChannels)
+        self.normNumGroups = try container.decode(Int.self, forKey: .normNumGroups)
+        self.downBlockTypes = try container.decode([String].self, forKey: .downBlockTypes)
+        self.additionEmbedType = try container.decodeIfPresent(
+            String.self, forKey: .additionEmbedType)
+        self.additionTimeEmbedDimension = try container.decodeIfPresent(
+            Int.self, forKey: .additionTimeEmbedDimension)
+        self.projectionClassEmbeddingsInputDimension = try container.decodeIfPresent(
+            Int.self, forKey: .projectionClassEmbeddingsInputDimension)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container: KeyedEncodingContainer<UNetConfiguration.CodingKeys> = encoder.container(
+            keyedBy: UNetConfiguration.CodingKeys.self)
+
+        try container.encode(self.upBlockTypes.reversed(), forKey: .upBlockTypes)
+
+        try container.encode(self.inputChannels, forKey: .inputChannels)
+        try container.encode(self.outputChannels, forKey: .outputChannels)
+        try container.encode(self.convolutionInKernel, forKey: .convolutionInKernel)
+        try container.encode(self.convolutionOutKernel, forKey: .convolutionOutKernel)
+        try container.encode(self.blockOutChannels, forKey: .blockOutChannels)
+        try container.encode(self.layersPerBlock, forKey: .layersPerBlock)
+        try container.encode(self.midBlockLayers, forKey: .midBlockLayers)
+        try container.encode(self.transformerLayersPerBlock, forKey: .transformerLayersPerBlock)
+        try container.encode(self.numHeads, forKey: .numHeads)
+        try container.encode(self.crossAttentionDimension, forKey: .crossAttentionDimension)
+        try container.encode(self.normNumGroups, forKey: .normNumGroups)
+        try container.encode(self.downBlockTypes, forKey: .downBlockTypes)
+        try container.encodeIfPresent(self.additionEmbedType, forKey: .additionEmbedType)
+        try container.encodeIfPresent(
+            self.additionTimeEmbedDimension, forKey: .additionTimeEmbedDimension)
+        try container.encodeIfPresent(
+            self.projectionClassEmbeddingsInputDimension,
+            forKey: .projectionClassEmbeddingsInputDimension)
+    }
+}
+
+/// Configuration for ``StableDiffusion``
+public struct DiffusionConfiguration: Codable {
+
+    public enum BetaSchedule: String, Codable {
+        case linear = "linear"
+        case scaledLinear = "scaled_linear"
+    }
+
+    public var betaSchedule = BetaSchedule.scaledLinear
+    public var betaStart: Float = 0.00085
+    public var betaEnd: Float = 0.012
+    public var trainSteps = 3
+
+    enum CodingKeys: String, CodingKey {
+        case betaSchedule = "beta_schedule"
+        case betaStart = "beta_start"
+        case betaEnd = "beta_end"
+        case trainSteps = "num_train_timesteps"
+    }
+}

--- a/Libraries/StableDiffusion/Image.swift
+++ b/Libraries/StableDiffusion/Image.swift
@@ -1,0 +1,127 @@
+// Copyright © 2024 Apple Inc.
+
+import CoreGraphics
+import Foundation
+import ImageIO
+import MLX
+import UniformTypeIdentifiers
+
+enum ImageError: Error {
+    case failedToSave
+    case unableToOpen
+}
+
+/// Conversion utilities for moving between `MLXArray`, `CGImage` and files.
+public struct Image {
+
+    public let data: MLXArray
+
+    /// Create an Image from a MLXArray with ndim == 3
+    public init(_ data: MLXArray) {
+        precondition(data.ndim == 3)
+        self.data = data
+    }
+
+    /// Create an Image by loading from a file
+    public init(url: URL, maximumEdge: Int? = nil) throws {
+        guard let source = CGImageSourceCreateWithURL(url as CFURL, nil),
+            let image = CGImageSourceCreateImageAtIndex(source, 0, nil)
+        else {
+            throw ImageError.unableToOpen
+        }
+
+        self.init(image: image)
+    }
+
+    /// Create an image from a CGImage
+    public init(image: CGImage, maximumEdge: Int? = nil) {
+        // ensure the sizes ar multiples of 64 -- this doesn't worry about
+        // the aspect ratio
+
+        var width = image.width
+        var height = image.height
+
+        if let maximumEdge {
+            func scale(_ edge: Int, _ maxEdge: Int) -> Int {
+                Int(round(Float(maximumEdge) / Float(maxEdge) * Float(edge)))
+            }
+
+            // aspect fit inside the given maximum
+            if width >= height {
+                width = scale(width, image.width)
+                height = scale(height, image.width)
+            } else {
+                width = scale(width, image.height)
+                height = scale(height, image.height)
+            }
+        }
+
+        // size must be multiples of 64 -- coerce without regard to aspect ratio
+        width = width - width % 64
+        height = height - height % 64
+
+        var raster = Data(count: width * 4 * height)
+        raster.withUnsafeMutableBytes { ptr in
+            let cs = CGColorSpace(name: CGColorSpace.sRGB)!
+            let context = CGContext(
+                data: ptr.baseAddress, width: width, height: height, bitsPerComponent: 8,
+                bytesPerRow: width * 4, space: cs,
+                bitmapInfo: CGImageAlphaInfo.noneSkipLast.rawValue
+                    | CGBitmapInfo.byteOrder32Big.rawValue)!
+
+            context.draw(
+                image, in: CGRect(origin: .zero, size: .init(width: width, height: height)))
+        }
+
+        self.data = MLXArray(raster, [height, width, 4], type: UInt8.self)[0..., 0..., ..<3]
+    }
+
+    /// Convert the image data to a CGImage
+    public func asCGImage() -> CGImage {
+        var raster = data
+
+        // we need 4 bytes per pixel
+        if data.dim(-1) == 3 {
+            raster = padded(raster, widths: [0, 0, [0, 1]])
+        }
+
+        class DataHolder {
+            var data: Data
+            init(_ data: Data) {
+                self.data = data
+            }
+        }
+
+        let holder = DataHolder(raster.asData())
+
+        let payload = Unmanaged.passRetained(holder).toOpaque()
+        func release(payload: UnsafeMutableRawPointer?, data: UnsafeMutableRawPointer?) {
+            Unmanaged<DataHolder>.fromOpaque(payload!).release()
+        }
+
+        return holder.data.withUnsafeMutableBytes { ptr in
+            let (H, W, C) = raster.shape3
+            let cs = CGColorSpace(name: CGColorSpace.sRGB)!
+
+            let context = CGContext(
+                data: ptr.baseAddress, width: W, height: H, bitsPerComponent: 8, bytesPerRow: W * C,
+                space: cs,
+                bitmapInfo: CGImageAlphaInfo.noneSkipLast.rawValue
+                    | CGBitmapInfo.byteOrder32Big.rawValue, releaseCallback: release,
+                releaseInfo: payload)!
+            return context.makeImage()!
+        }
+    }
+
+    /// Save the image
+    public func save(url: URL) throws {
+        let uti = UTType(filenameExtension: url.pathExtension) ?? UTType.png
+
+        let destination = CGImageDestinationCreateWithURL(
+            url as CFURL, uti.identifier as CFString, 1, nil)!
+        CGImageDestinationAddImage(destination, asCGImage(), nil)
+        if !CGImageDestinationFinalize(destination) {
+            throw ImageError.failedToSave
+        }
+    }
+}

--- a/Libraries/StableDiffusion/Load.swift
+++ b/Libraries/StableDiffusion/Load.swift
@@ -1,0 +1,459 @@
+// Copyright © 2024 Apple Inc.
+
+import Foundation
+import Hub
+import MLX
+import MLXNN
+
+// port of https://github.com/ml-explore/mlx-examples/blob/main/stable_diffusion/stable_diffusion/model_io.py
+
+/// Configuration for loading stable diffusion weights.
+///
+/// These options can be tuned to conserve memory.
+public struct LoadConfiguration: Sendable {
+
+    /// convert weights to float16
+    public var float16 = true
+
+    /// quantize weights
+    public var quantize = false
+
+    public var dType: DType {
+        float16 ? .float16 : .float32
+    }
+
+    public init(float16: Bool = true, quantize: Bool = false) {
+        self.float16 = float16
+        self.quantize = quantize
+    }
+}
+
+/// Parameters for evaluating a stable diffusion prompt and generating latents
+public struct EvaluateParameters: Sendable {
+
+    /// `cfg` value from the preset
+    public var cfgWeight: Float
+
+    /// number of steps -- default is from the preset
+    public var steps: Int
+
+    /// number of images to generate at a time
+    public var imageCount = 1
+    public var decodingBatchSize = 1
+
+    /// size of the latent tensor -- the result image is a factor of 8 larger than this
+    public var latentSize = [64, 64]
+
+    public var seed: UInt64
+    public var prompt = ""
+    public var negativePrompt = ""
+
+    public init(
+        cfgWeight: Float, steps: Int, imageCount: Int = 1, decodingBatchSize: Int = 1,
+        latentSize: [Int] = [64, 64], seed: UInt64? = nil, prompt: String = "",
+        negativePrompt: String = ""
+    ) {
+        self.cfgWeight = cfgWeight
+        self.steps = steps
+        self.imageCount = imageCount
+        self.decodingBatchSize = decodingBatchSize
+        self.latentSize = latentSize
+        self.seed = seed ?? UInt64(Date.timeIntervalSinceReferenceDate * 1000)
+        self.prompt = prompt
+        self.negativePrompt = negativePrompt
+    }
+}
+
+/// File types for ``StableDiffusionConfiguration/files``.  Used by the presets to provide
+/// relative file paths for different types of files.
+enum FileKey {
+    case unetConfig
+    case unetWeights
+    case textEncoderConfig
+    case textEncoderWeights
+    case textEncoderConfig2
+    case textEncoderWeights2
+    case vaeConfig
+    case vaeWeights
+    case diffusionConfig
+    case tokenizerVocabulary
+    case tokenizerMerges
+    case tokenizerVocabulary2
+    case tokenizerMerges2
+}
+
+/// Stable diffusion configuration -- this selects the model to load.
+///
+/// Use the preset values:
+/// - ``presetSDXLTurbo``
+/// - ``presetStableDiffusion21Base``
+///
+/// or use the enum (convenient for command line tools):
+///
+/// - ``Preset/sdxlTurbo``
+/// - ``Preset/sdxlTurbo``
+///
+/// Call ``download(hub:progressHandler:)`` to download the weights, then
+/// ``textToImageGenerator(hub:configuration:)`` or
+/// ``imageToImageGenerator(hub:configuration:)`` to produce the ``ImageGenerator``.
+///
+/// The ``ImageGenerator`` has a method to generate the latents:
+/// - ``TextToImageGenerator/generateLatents(parameters:)``
+/// - ``ImageToImageGenerator/generateLatents(image:parameters:strength:)``
+///
+/// Evaluate each of the latents from that iterator and use the decoder to turn the last latent
+/// into an image:
+///
+/// - ``ImageGenerator/decode(xt:)``
+///
+/// Finally use ``Image`` to save it to a file or convert to a CGImage for display.
+public struct StableDiffusionConfiguration: Sendable {
+    public let id: String
+    let files: [FileKey: String]
+    public let defaultParameters: @Sendable () -> EvaluateParameters
+    let factory:
+        @Sendable (HubApi, StableDiffusionConfiguration, LoadConfiguration) throws ->
+            StableDiffusion
+
+    public func download(
+        hub: HubApi = HubApi(), progressHandler: @escaping (Progress) -> Void = { _ in }
+    ) async throws {
+        let repo = Hub.Repo(id: self.id)
+        try await hub.snapshot(
+            from: repo, matching: Array(files.values), progressHandler: progressHandler)
+    }
+
+    public func textToImageGenerator(hub: HubApi = HubApi(), configuration: LoadConfiguration)
+        throws -> TextToImageGenerator?
+    {
+        try factory(hub, self, configuration) as? TextToImageGenerator
+    }
+
+    public func imageToImageGenerator(hub: HubApi = HubApi(), configuration: LoadConfiguration)
+        throws -> ImageToImageGenerator?
+    {
+        try factory(hub, self, configuration) as? ImageToImageGenerator
+    }
+
+    public enum Preset: String, Codable, CaseIterable, Sendable {
+        case base
+        case sdxlTurbo = "sdxl-turbo"
+
+        public var configuration: StableDiffusionConfiguration {
+            switch self {
+            case .base: presetStableDiffusion21Base
+            case .sdxlTurbo: presetSDXLTurbo
+            }
+        }
+    }
+
+    /// See https://huggingface.co/stabilityai/sdxl-turbo for the model details and license
+    public static let presetSDXLTurbo = StableDiffusionConfiguration(
+        id: "stabilityai/sdxl-turbo",
+        files: [
+            .unetConfig: "unet/config.json",
+            .unetWeights: "unet/diffusion_pytorch_model.safetensors",
+            .textEncoderConfig: "text_encoder/config.json",
+            .textEncoderWeights: "text_encoder/model.safetensors",
+            .textEncoderConfig2: "text_encoder_2/config.json",
+            .textEncoderWeights2: "text_encoder_2/model.safetensors",
+            .vaeConfig: "vae/config.json",
+            .vaeWeights: "vae/diffusion_pytorch_model.safetensors",
+            .diffusionConfig: "scheduler/scheduler_config.json",
+            .tokenizerVocabulary: "tokenizer/vocab.json",
+            .tokenizerMerges: "tokenizer/merges.txt",
+            .tokenizerVocabulary2: "tokenizer_2/vocab.json",
+            .tokenizerMerges2: "tokenizer_2/merges.txt",
+        ],
+        defaultParameters: { EvaluateParameters(cfgWeight: 0, steps: 2) },
+        factory: { hub, sdConfiguration, loadConfiguration in
+            let sd = try StableDiffusionXL(
+                hub: hub, configuration: sdConfiguration, dType: loadConfiguration.dType)
+            if loadConfiguration.quantize {
+                quantize(model: sd.textEncoder, filter: { k, m in m is Linear })
+                quantize(model: sd.textEncoder2, filter: { k, m in m is Linear })
+                quantize(model: sd.unet, groupSize: 32, bits: 8)
+            }
+            return sd
+        }
+    )
+
+    /// See https://huggingface.co/stabilityai/stable-diffusion-2-1-base for the model details and license
+    public static let presetStableDiffusion21Base = StableDiffusionConfiguration(
+        id: "stabilityai/stable-diffusion-2-1-base",
+        files: [
+            .unetConfig: "unet/config.json",
+            .unetWeights: "unet/diffusion_pytorch_model.safetensors",
+            .textEncoderConfig: "text_encoder/config.json",
+            .textEncoderWeights: "text_encoder/model.safetensors",
+            .vaeConfig: "vae/config.json",
+            .vaeWeights: "vae/diffusion_pytorch_model.safetensors",
+            .diffusionConfig: "scheduler/scheduler_config.json",
+            .tokenizerVocabulary: "tokenizer/vocab.json",
+            .tokenizerMerges: "tokenizer/merges.txt",
+        ],
+        defaultParameters: { EvaluateParameters(cfgWeight: 7.5, steps: 50) },
+        factory: { hub, sdConfiguration, loadConfiguration in
+            let sd = try StableDiffusionBase(
+                hub: hub, configuration: sdConfiguration, dType: loadConfiguration.dType)
+            if loadConfiguration.quantize {
+                quantize(model: sd.textEncoder, filter: { k, m in m is Linear })
+                quantize(model: sd.unet, groupSize: 32, bits: 8)
+            }
+            return sd
+        }
+    )
+
+}
+
+// MARK: - Key Mapping
+
+func keyReplace(_ replace: String, _ with: String) -> @Sendable (String) -> String? {
+    return { [replace, with] key in
+        if key.contains(replace) {
+            return key.replacingOccurrences(of: replace, with: with)
+        }
+        return nil
+    }
+}
+
+func dropPrefix(_ prefix: String) -> @Sendable (String) -> String? {
+    return { [prefix] key in
+        if key.hasPrefix(prefix) {
+            return String(key.dropFirst(prefix.count))
+        }
+        return nil
+    }
+}
+
+// see map_unet_weights()
+
+let unetRules: [@Sendable (String) -> String?] = [
+    // Map up/downsampling
+    keyReplace("downsamplers.0.conv", "downsample"),
+    keyReplace("upsamplers.0.conv", "upsample"),
+
+    // Map the mid block
+    keyReplace("mid_block.resnets.0", "mid_blocks.0"),
+    keyReplace("mid_block.attentions.0", "mid_blocks.1"),
+    keyReplace("mid_block.resnets.1", "mid_blocks.2"),
+
+    // Map attention layers
+    keyReplace("to_k", "key_proj"),
+    keyReplace("to_out.0", "out_proj"),
+    keyReplace("to_q", "query_proj"),
+    keyReplace("to_v", "value_proj"),
+
+    // Map transformer ffn
+    keyReplace("ff.net.2", "linear3"),
+]
+
+func unetRemap(key: String, value: MLXArray) -> [(String, MLXArray)] {
+    var key = key
+    var value = value
+
+    for rule in unetRules {
+        key = rule(key) ?? key
+    }
+
+    // Map transformer ffn
+    if key.contains("ff.net.0") {
+        let k1 = key.replacingOccurrences(of: "ff.net.0.proj", with: "linear1")
+        let k2 = key.replacingOccurrences(of: "ff.net.0.proj", with: "linear2")
+        let (v1, v2) = value.split()
+        return [(k1, v1), (k2, v2)]
+    }
+
+    if key.contains("conv_shortcut.weight") {
+        value = value.squeezed()
+    }
+
+    // Transform the weights from 1x1 convs to linear
+    if value.ndim == 4 && (key.contains("proj_in") || key.contains("proj_out")) {
+        value = value.squeezed()
+    }
+
+    if value.ndim == 4 {
+        value = value.transposed(0, 2, 3, 1)
+        value = value.reshaped(-1).reshaped(value.shape)
+    }
+
+    return [(key, value)]
+}
+
+let clipRules: [@Sendable (String) -> String?] = [
+    dropPrefix("text_model."),
+    dropPrefix("embeddings."),
+    dropPrefix("encoder."),
+
+    // Map attention layers
+    keyReplace("self_attn.", "attention."),
+    keyReplace("q_proj.", "query_proj."),
+    keyReplace("k_proj.", "key_proj."),
+    keyReplace("v_proj.", "value_proj."),
+
+    // Map ffn layers
+    keyReplace("mlp.fc1", "linear1"),
+    keyReplace("mlp.fc2", "linear2"),
+]
+
+func clipRemap(key: String, value: MLXArray) -> [(String, MLXArray)] {
+    var key = key
+
+    for rule in clipRules {
+        key = rule(key) ?? key
+    }
+
+    // not used
+    if key == "position_ids" {
+        return []
+    }
+
+    return [(key, value)]
+}
+
+let vaeRules: [@Sendable (String) -> String?] = [
+    // Map up/downsampling
+    keyReplace("downsamplers.0.conv", "downsample"),
+    keyReplace("upsamplers.0.conv", "upsample"),
+
+    // Map attention layers
+    keyReplace("to_k", "key_proj"),
+    keyReplace("to_out.0", "out_proj"),
+    keyReplace("to_q", "query_proj"),
+    keyReplace("to_v", "value_proj"),
+
+    // Map the mid block
+    keyReplace("mid_block.resnets.0", "mid_blocks.0"),
+    keyReplace("mid_block.attentions.0", "mid_blocks.1"),
+    keyReplace("mid_block.resnets.1", "mid_blocks.2"),
+
+    keyReplace("mid_blocks.1.key.", "mid_blocks.1.key_proj."),
+    keyReplace("mid_blocks.1.query.", "mid_blocks.1.query_proj."),
+    keyReplace("mid_blocks.1.value.", "mid_blocks.1.value_proj."),
+    keyReplace("mid_blocks.1.proj_attn.", "mid_blocks.1.out_proj."),
+
+]
+
+func vaeRemap(key: String, value: MLXArray) -> [(String, MLXArray)] {
+    var key = key
+    var value = value
+
+    for rule in vaeRules {
+        key = rule(key) ?? key
+    }
+
+    // Map the quant/post_quant layers
+    if key.contains("quant_conv") {
+        key = key.replacingOccurrences(of: "quant_conv", with: "quant_proj")
+        value = value.squeezed()
+    }
+
+    // Map the conv_shortcut to linear
+    if key.contains("conv_shortcut.weight") {
+        value = value.squeezed()
+    }
+
+    if value.ndim == 4 {
+        value = value.transposed(0, 2, 3, 1)
+        value = value.reshaped(-1).reshaped(value.shape)
+    }
+
+    return [(key, value)]
+}
+
+func loadWeights(
+    url: URL, model: Module, mapper: (String, MLXArray) -> [(String, MLXArray)], dType: DType
+) throws {
+    let weights = try loadArrays(url: url).flatMap { mapper($0.key, $0.value.asType(dType)) }
+
+    // Note: not using verifier because some shapes change upon load
+    try model.update(parameters: ModuleParameters.unflattened(weights), verify: .none)
+}
+
+// MARK: - Loading
+
+func resolve(hub: HubApi, configuration: StableDiffusionConfiguration, key: FileKey) -> URL {
+    precondition(
+        configuration.files[key] != nil, "configuration \(configuration.id) missing key: \(key)")
+    let repo = Hub.Repo(id: configuration.id)
+    let directory = hub.localRepoLocation(repo)
+    return directory.appending(component: configuration.files[key]!)
+}
+
+func loadConfiguration<T: Decodable>(
+    hub: HubApi, configuration: StableDiffusionConfiguration, key: FileKey, type: T.Type
+) throws -> T {
+    let url = resolve(hub: hub, configuration: configuration, key: key)
+    return try JSONDecoder().decode(T.self, from: Data(contentsOf: url))
+}
+
+func loadUnet(hub: HubApi, configuration: StableDiffusionConfiguration, dType: DType) throws
+    -> UNetModel
+{
+    let unetConfiguration = try loadConfiguration(
+        hub: hub, configuration: configuration, key: .unetConfig, type: UNetConfiguration.self)
+    let model = UNetModel(configuration: unetConfiguration)
+
+    let weightsURL = resolve(hub: hub, configuration: configuration, key: .unetWeights)
+    try loadWeights(url: weightsURL, model: model, mapper: unetRemap, dType: dType)
+
+    return model
+}
+
+func loadTextEncoder(
+    hub: HubApi, configuration: StableDiffusionConfiguration,
+    configKey: FileKey = .textEncoderConfig, weightsKey: FileKey = .textEncoderWeights, dType: DType
+) throws -> CLIPTextModel {
+    let clipConfiguration = try loadConfiguration(
+        hub: hub, configuration: configuration, key: configKey,
+        type: CLIPTextModelConfiguration.self)
+    let model = CLIPTextModel(configuration: clipConfiguration)
+
+    let weightsURL = resolve(hub: hub, configuration: configuration, key: weightsKey)
+    try loadWeights(url: weightsURL, model: model, mapper: clipRemap, dType: dType)
+
+    return model
+}
+
+func loadAutoEncoder(hub: HubApi, configuration: StableDiffusionConfiguration, dType: DType) throws
+    -> Autoencoder
+{
+    let autoEncoderConfiguration = try loadConfiguration(
+        hub: hub, configuration: configuration, key: .vaeConfig, type: AutoencoderConfiguration.self
+    )
+    let model = Autoencoder(configuration: autoEncoderConfiguration)
+
+    let weightsURL = resolve(hub: hub, configuration: configuration, key: .vaeWeights)
+    try loadWeights(url: weightsURL, model: model, mapper: vaeRemap, dType: dType)
+
+    return model
+}
+
+func loadDiffusionConfiguration(hub: HubApi, configuration: StableDiffusionConfiguration) throws
+    -> DiffusionConfiguration
+{
+    try loadConfiguration(
+        hub: hub, configuration: configuration, key: .diffusionConfig,
+        type: DiffusionConfiguration.self)
+}
+
+// MARK: - Tokenizer
+
+func loadTokenizer(
+    hub: HubApi, configuration: StableDiffusionConfiguration,
+    vocabulary: FileKey = .tokenizerVocabulary, merges: FileKey = .tokenizerMerges
+) throws -> CLIPTokenizer {
+    let vocabularyURL = resolve(hub: hub, configuration: configuration, key: vocabulary)
+    let mergesURL = resolve(hub: hub, configuration: configuration, key: merges)
+
+    let vocabulary = try JSONDecoder().decode(
+        [String: Int].self, from: Data(contentsOf: vocabularyURL))
+    let merges = try String(contentsOf: mergesURL)
+        .components(separatedBy: .newlines)
+        // first line is a comment
+        .dropFirst()
+        .filter { !$0.isEmpty }
+
+    return CLIPTokenizer(merges: merges, vocabulary: vocabulary)
+}

--- a/Libraries/StableDiffusion/README.md
+++ b/Libraries/StableDiffusion/README.md
@@ -1,0 +1,57 @@
+#  Stable Diffusion
+
+Stable Diffusion in MLX. The implementation was ported from Hugging Face's
+[diffusers](https://huggingface.co/docs/diffusers/index) and 
+[mlx-examples/stable_diffusion](https://github.com/ml-explore/mlx-examples/tree/main/stable_diffusion).
+Model weights are downloaded directly from the Hugging Face hub. The implementation currently
+supports the following models:
+
+- [stabilityai/sdxl-turbo](https://huggingface.co/stabilityai/sdxl-turbo)
+- [stabilitiai/stable-diffusion-2-1](https://huggingface.co/stabilityai/stable-diffusion-2-1)
+
+## Usage
+
+See [StableDiffusionExample](../../Applications/StableDiffusionExample) and
+[image-tool](../../Tools/image-tool) for examples of using this code.
+
+The basic sequence is:
+
+- download & load the model
+- generate latents
+- evaluate the latents one by one
+- decode the last latent generated
+- you have an image!
+
+```swift
+let configuration = StableDiffusionConfiguration.presetSDXLTurbo
+
+let generator = try configuration.textToImageGenerator(
+    configuration: model.loadConfiguration)
+
+generator.ensureLoaded()
+
+// generate the latents -- these are the iterations for generating
+// the output image.  this is just generating the evaluation graph
+let parameters = generate.evaluateParameters(configuration: configuration)
+let latents = generator.generateLatents(parameters: parameters)
+
+// evaluate the latents (evalue the graph) and keep the last value generated
+var lastXt: MLXArray?
+for xt in latents {
+    eval(xt)
+    lastXt = xt
+}
+
+// decode the final latent into an image
+if let lastXt {
+    var raster = decoder(lastXt[0])
+    raster = (image * 255).asType(.uint8).squeezed()
+    eval(raster)
+    
+    // turn it into a CGImage
+    let image = Image(raster).asCGImage()
+    
+    // or write it out
+    try Image(raster).save(url: url)
+}
+```

--- a/Libraries/StableDiffusion/Sampler.swift
+++ b/Libraries/StableDiffusion/Sampler.swift
@@ -1,0 +1,118 @@
+// Copyright © 2024 Apple Inc.
+
+import Foundation
+import MLX
+import MLXRandom
+
+// port of https://github.com/ml-explore/mlx-examples/blob/main/stable_diffusion/stable_diffusion/sampler.py
+
+/// Interpolate the function defined by `(0 ..< y.count) y)` at positions `xNew`.
+func interpolate(y: MLXArray, xNew: MLXArray) -> MLXArray {
+    let xLow = xNew.asType(.int32)
+    let xHigh = minimum(xLow + 1, y.count - 1)
+
+    let yLow = y[xLow]
+    let yHigh = y[xHigh]
+    let deltaX = xNew - xLow
+    let yNew = yLow * (1 - deltaX) + deltaX * yHigh
+
+    return yNew
+}
+
+/// A simple Euler integrator that can be used to sample from our diffusion models.
+///
+/// The method ``step()`` performs one Euler step from `x_t` to `x_t_prev`.
+class SimpleEulerSampler {
+
+    let sigmas: MLXArray
+
+    public init(configuration: DiffusionConfiguration) {
+        let betas: MLXArray
+
+        // compute the noise schedule
+        switch configuration.betaSchedule {
+        case .linear:
+            betas = MLXArray.linspace(
+                configuration.betaStart, configuration.betaEnd, count: configuration.trainSteps)
+        case .scaledLinear:
+            betas = MLXArray.linspace(
+                sqrt(configuration.betaStart), sqrt(configuration.betaEnd),
+                count: configuration.trainSteps
+            ).square()
+        }
+
+        let alphas = 1 - betas
+        let alphasCumprod = cumprod(alphas)
+
+        self.sigmas = concatenated([
+            MLXArray.zeros([1]), ((1 - alphasCumprod) / alphasCumprod).sqrt(),
+        ])
+    }
+
+    public var maxTime: Int {
+        sigmas.count - 1
+    }
+
+    public func samplePrior(shape: [Int], dType: DType = .float32, key: MLXArray? = nil) -> MLXArray
+    {
+        let noise = MLXRandom.normal(shape, key: key)
+        return (noise * sigmas[-1] * (sigmas[-1].square() + 1).rsqrt()).asType(dType)
+    }
+
+    public func addNoise(x: MLXArray, t: MLXArray, key: MLXArray? = nil) -> MLXArray {
+        let noise = MLXRandom.normal(x.shape, key: key)
+        let s = sigmas(t)
+        return (x + noise * s) * (s.square() + 1).rsqrt()
+    }
+
+    public func sigmas(_ t: MLXArray) -> MLXArray {
+        interpolate(y: sigmas, xNew: t)
+    }
+
+    public func timeSteps(steps: Int, start: Int? = nil, dType: DType = .float32) -> [(
+        MLXArray, MLXArray
+    )] {
+        let start = start ?? (sigmas.count - 1)
+        precondition(0 < start)
+        precondition(start <= sigmas.count - 1)
+        let steps = MLX.linspace(start, 0, count: steps + 1).asType(dType)
+
+        return Array(zip(steps, steps[1...]))
+    }
+
+    open func step(epsPred: MLXArray, xt: MLXArray, t: MLXArray, tPrev: MLXArray) -> MLXArray {
+        let dtype = epsPred.dtype
+        let sigma = sigmas(t).asType(dtype)
+        let sigmaPrev = sigmas(tPrev).asType(dtype)
+
+        let dt = sigmaPrev - sigma
+        var xtPrev = (sigma.square() + 1).sqrt() * xt + epsPred * dt
+        xtPrev = xtPrev * (sigmaPrev.square() + 1).rsqrt()
+
+        return xtPrev
+    }
+}
+
+class SimpleEulerAncestralSampler: SimpleEulerSampler {
+
+    open override func step(epsPred: MLXArray, xt: MLXArray, t: MLXArray, tPrev: MLXArray)
+        -> MLXArray
+    {
+        let dtype = epsPred.dtype
+        let sigma = sigmas(t).asType(dtype)
+        let sigmaPrev = sigmas(tPrev).asType(dtype)
+
+        let sigma2 = sigma.square()
+        let sigmaPrev2 = sigmaPrev.square()
+        let sigmaUp = (sigmaPrev2 * (sigma2 - sigmaPrev2) / sigma2).sqrt()
+        let sigmaDown = (sigmaPrev2 - sigmaUp ** 2).sqrt()
+
+        let dt = sigmaDown - sigma
+        var xtPrev = (sigma2 + 1).sqrt() * xt + epsPred * dt
+        let noise = MLXRandom.normal(xtPrev.shape).asType(xtPrev.dtype)
+        xtPrev = xtPrev + noise * sigmaUp
+        xtPrev = xtPrev * (sigmaPrev2 + 1).rsqrt()
+
+        return xtPrev
+    }
+}

--- a/Libraries/StableDiffusion/StableDiffusion.swift
+++ b/Libraries/StableDiffusion/StableDiffusion.swift
@@ -147,7 +147,7 @@ public actor ModelContainer<M> {
         }
     }
 
-    public func setConservativeMemory(_ conserveMemory: Bool) {
+    public func setConserveMemory(_ conserveMemory: Bool) {
         self.conserveMemory = conserveMemory
     }
 

--- a/Libraries/StableDiffusion/StableDiffusion.swift
+++ b/Libraries/StableDiffusion/StableDiffusion.swift
@@ -1,0 +1,438 @@
+// Copyright © 2024 Apple Inc.
+
+import Foundation
+import Hub
+import MLX
+import MLXNN
+import MLXRandom
+
+// port of https://github.com/ml-explore/mlx-examples/blob/main/stable_diffusion/stable_diffusion/__init__.py
+
+/// Iterator that produces latent images.
+///
+/// Created by:
+///
+/// - ``TextToImageGenerator/generateLatents(parameters:)``
+/// - ``ImageToImageGenerator/generateLatents(image:parameters:strength:)``
+public struct DenoiseIterator: Sequence, IteratorProtocol {
+
+    let sd: StableDiffusion
+
+    var xt: MLXArray
+
+    let conditioning: MLXArray
+    let cfgWeight: Float
+    let textTime: (MLXArray, MLXArray)?
+
+    var i: Int
+    let steps: [(MLXArray, MLXArray)]
+
+    init(
+        sd: StableDiffusion, xt: MLXArray, t: Int, conditioning: MLXArray, steps: Int,
+        cfgWeight: Float, textTime: (MLXArray, MLXArray)? = nil
+    ) {
+        self.sd = sd
+        self.steps = sd.sampler.timeSteps(steps: steps, start: t, dType: sd.dType)
+        self.i = 0
+        self.xt = xt
+        self.conditioning = conditioning
+        self.cfgWeight = cfgWeight
+        self.textTime = textTime
+    }
+
+    public var underestimatedCount: Int {
+        steps.count
+    }
+
+    mutating public func next() -> MLXArray? {
+        guard i < steps.count else {
+            return nil
+        }
+
+        let (t, tPrev) = steps[i]
+        i += 1
+
+        xt = sd.step(
+            xt: xt, t: t, tPrev: tPrev, conditioning: conditioning, cfgWeight: cfgWeight,
+            textTime: textTime)
+        return xt
+    }
+}
+
+/// Type for the _decoder_ step.
+public typealias ImageDecoder = (MLXArray) -> MLXArray
+
+public protocol ImageGenerator {
+    func ensureLoaded()
+
+    /// Return a detached decoder -- this is useful if trying to conserve memory.
+    ///
+    /// The decoder can be used independently of the ImageGenerator to transform
+    /// latents into raster images.
+    func detachedDecoder() -> ImageDecoder
+
+    /// the equivalent to the ``detachedDecoder()`` but without the detatching
+    func decode(xt: MLXArray) -> MLXArray
+}
+
+/// Public interface for transforming a text prompt into an image.
+///
+/// Steps:
+///
+/// - ``generateLatents(parameters:)``
+/// - evaluate each of the latents from the iterator
+/// - ``ImageGenerator/decode(xt:)`` or ``ImageGenerator/detachedDecoder()`` to convert the final latent into an image
+/// - use ``Image`` to save the image
+public protocol TextToImageGenerator: ImageGenerator {
+    func generateLatents(parameters: EvaluateParameters) -> DenoiseIterator
+}
+
+/// Public interface for transforming a text prompt into an image.
+///
+/// Steps:
+///
+/// - ``generateLatents(image:parameters:strength:)``
+/// - evaluate each of the latents from the iterator
+/// - ``ImageGenerator/decode(xt:)`` or ``ImageGenerator/detachedDecoder()`` to convert the final latent into an image
+/// - use ``Image`` to save the image
+public protocol ImageToImageGenerator: ImageGenerator {
+    func generateLatents(image: MLXArray, parameters: EvaluateParameters, strength: Float)
+        -> DenoiseIterator
+}
+
+enum ModelContainerError: Error {
+    /// unable to create the particular type of model, e.g. it doesn't support image to image
+    case unableToCreate(String, String)
+
+    /// when operating in conserveMemory mode it tried to use a model that had been discarded
+    case modelDiscarded
+}
+
+/// Container for models that guarantees single threaded access.
+public actor ModelContainer<M> {
+
+    enum State {
+        case discarded
+        case loaded(M)
+    }
+
+    var state: State
+
+    /// if true this will discard the model in ``performTwoStage(first:second:)``
+    var conserveMemory = false
+
+    private init(model: M) {
+        self.state = .loaded(model)
+    }
+
+    /// create a ``ModelContainer`` that supports ``TextToImageGenerator``
+    static public func createTextToImageGenerator(
+        configuration: StableDiffusionConfiguration, loadConfiguration: LoadConfiguration = .init()
+    ) throws -> ModelContainer<TextToImageGenerator> {
+        if let model = try configuration.textToImageGenerator(configuration: loadConfiguration) {
+            return .init(model: model)
+        } else {
+            throw ModelContainerError.unableToCreate(configuration.id, "TextToImageGenerator")
+        }
+    }
+
+    /// create a ``ModelContainer`` that supports ``ImageToImageGenerator``
+    static public func createImageToImageGenerator(
+        configuration: StableDiffusionConfiguration, loadConfiguration: LoadConfiguration = .init()
+    ) throws -> ModelContainer<ImageToImageGenerator> {
+        if let model = try configuration.imageToImageGenerator(configuration: loadConfiguration) {
+            return .init(model: model)
+        } else {
+            throw ModelContainerError.unableToCreate(configuration.id, "ImageToImageGenerator")
+        }
+    }
+
+    public func setConservativeMemory(_ conserveMemory: Bool) {
+        self.conserveMemory = conserveMemory
+    }
+
+    /// Perform an action on the model and/or tokenizer.  Callers _must_ eval any `MLXArray` before returning as
+    /// `MLXArray` is not `Sendable`.
+    public func perform<R>(_ action: @Sendable (M) throws -> R) throws -> R {
+        switch state {
+        case .discarded:
+            throw ModelContainerError.modelDiscarded
+        case .loaded(let m):
+            try action(m)
+        }
+    }
+
+    /// Perform a two stage action where the first stage returns values passed to the second stage.
+    ///
+    /// If ``setConservativeMemory(_:)`` is `true` this will discard the model in between
+    /// the `first` and `second` blocks.  The container will have to be recreated if a caller
+    /// wants to use it again.
+    ///
+    /// If `false` this will just run them in sequence and the container can be reused.
+    ///
+    /// Callers _must_ eval any `MLXArray` before returning as `MLXArray` is not `Sendable`.
+    public func performTwoStage<R1, R2>(
+        first: @Sendable (M) throws -> R1, second: @Sendable (R1) throws -> R2
+    ) throws -> R2 {
+        let r1 =
+            switch state {
+            case .discarded:
+                throw ModelContainerError.modelDiscarded
+            case .loaded(let m):
+                try first(m)
+            }
+        if conserveMemory {
+            self.state = .discarded
+        }
+        return try second(r1)
+    }
+
+}
+
+/// Base class for Stable Diffusion.
+open class StableDiffusion {
+
+    let dType: DType
+    let diffusionConfiguration: DiffusionConfiguration
+    let unet: UNetModel
+    let textEncoder: CLIPTextModel
+    let autoencoder: Autoencoder
+    let sampler: SimpleEulerSampler
+    let tokenizer: CLIPTokenizer
+
+    internal init(
+        hub: HubApi, configuration: StableDiffusionConfiguration, dType: DType,
+        diffusionConfiguration: DiffusionConfiguration? = nil, unet: UNetModel? = nil,
+        textEncoder: CLIPTextModel? = nil, autoencoder: Autoencoder? = nil,
+        sampler: SimpleEulerSampler? = nil, tokenizer: CLIPTokenizer? = nil
+    ) throws {
+        self.dType = dType
+        self.diffusionConfiguration =
+            try diffusionConfiguration
+            ?? loadDiffusionConfiguration(hub: hub, configuration: configuration)
+        self.unet = try unet ?? loadUnet(hub: hub, configuration: configuration, dType: dType)
+        self.textEncoder =
+            try textEncoder ?? loadTextEncoder(hub: hub, configuration: configuration, dType: dType)
+
+        // note: autoencoder uses float32 weights
+        self.autoencoder =
+            try autoencoder
+            ?? loadAutoEncoder(hub: hub, configuration: configuration, dType: .float32)
+
+        if let sampler {
+            self.sampler = sampler
+        } else {
+            self.sampler = SimpleEulerSampler(configuration: self.diffusionConfiguration)
+        }
+        self.tokenizer = try tokenizer ?? loadTokenizer(hub: hub, configuration: configuration)
+    }
+
+    open func ensureLoaded() {
+        eval(unet, textEncoder, autoencoder)
+    }
+
+    func tokenize(tokenizer: CLIPTokenizer, text: String, negativeText: String?) -> MLXArray {
+        var tokens = [tokenizer.tokenize(text: text)]
+        if let negativeText {
+            tokens.append(tokenizer.tokenize(text: negativeText))
+        }
+
+        let c = tokens.count
+        let max = tokens.map { $0.count }.max() ?? 0
+        let mlxTokens = MLXArray(
+            tokens
+                .map {
+                    ($0 + Array(repeating: 0, count: max - $0.count))
+                }
+                .flatMap { $0 }
+        )
+        .reshaped(c, max)
+
+        return mlxTokens
+    }
+
+    open func step(
+        xt: MLXArray, t: MLXArray, tPrev: MLXArray, conditioning: MLXArray, cfgWeight: Float,
+        textTime: (MLXArray, MLXArray)?
+    ) -> MLXArray {
+        let xtUnet = cfgWeight > 1 ? repeated(xt, count: 2, axis: 0) : xt
+        let tUnet = broadcast(t, to: [xtUnet.count])
+
+        var epsPred = unet(xtUnet, timestep: tUnet, encoderX: conditioning, textTime: textTime)
+
+        if cfgWeight > 1 {
+            let (epsText, epsNeg) = epsPred.split()
+            epsPred = epsNeg + cfgWeight * (epsText - epsNeg)
+        }
+
+        return sampler.step(epsPred: epsPred, xt: xt, t: t, tPrev: tPrev)
+    }
+
+    public func detachedDecoder() -> ImageDecoder {
+        let autoencoder = self.autoencoder
+        func decode(xt: MLXArray) -> MLXArray {
+            var x = autoencoder.decode(xt)
+            x = clip(x / 2 + 0.5, min: 0, max: 1)
+            return x
+        }
+        return decode(xt:)
+    }
+
+    public func decode(xt: MLXArray) -> MLXArray {
+        detachedDecoder()(xt)
+    }
+}
+
+/// Implementation of ``StableDiffusion`` for the `stabilityai/stable-diffusion-2-1-base` model.
+open class StableDiffusionBase: StableDiffusion, TextToImageGenerator {
+
+    public init(hub: HubApi, configuration: StableDiffusionConfiguration, dType: DType) throws {
+        try super.init(hub: hub, configuration: configuration, dType: dType)
+    }
+
+    func conditionText(text: String, imageCount: Int, cfgWeight: Float, negativeText: String?)
+        -> MLXArray
+    {
+        // tokenize the text
+        let tokens = tokenize(
+            tokenizer: tokenizer, text: text, negativeText: cfgWeight > 1 ? negativeText : nil)
+
+        // compute the features
+        var conditioning = textEncoder(tokens).lastHiddenState
+
+        // repeat the conditioning for each of the generated images
+        if imageCount > 1 {
+            conditioning = repeated(conditioning, count: imageCount, axis: 0)
+        }
+
+        return conditioning
+    }
+
+    public func generateLatents(parameters: EvaluateParameters) -> DenoiseIterator {
+        MLXRandom.seed(parameters.seed)
+
+        let conditioning = conditionText(
+            text: parameters.prompt, imageCount: parameters.imageCount,
+            cfgWeight: parameters.cfgWeight, negativeText: parameters.negativePrompt)
+
+        let xt = sampler.samplePrior(
+            shape: [parameters.imageCount] + parameters.latentSize + [autoencoder.latentChannels],
+            dType: dType)
+
+        return DenoiseIterator(
+            sd: self, xt: xt, t: sampler.maxTime, conditioning: conditioning,
+            steps: parameters.steps, cfgWeight: parameters.cfgWeight)
+    }
+
+}
+
+/// Implementation of ``StableDiffusion`` for the `stabilityai/sdxl-turbo` model.
+open class StableDiffusionXL: StableDiffusion, TextToImageGenerator, ImageToImageGenerator {
+
+    let textEncoder2: CLIPTextModel
+    let tokenizer2: CLIPTokenizer
+
+    public init(hub: HubApi, configuration: StableDiffusionConfiguration, dType: DType) throws {
+        let diffusionConfiguration = try loadConfiguration(
+            hub: hub, configuration: configuration, key: .diffusionConfig,
+            type: DiffusionConfiguration.self)
+        let sampler = SimpleEulerAncestralSampler(configuration: diffusionConfiguration)
+
+        self.textEncoder2 = try loadTextEncoder(
+            hub: hub, configuration: configuration, configKey: .textEncoderConfig2,
+            weightsKey: .textEncoderWeights2, dType: dType)
+
+        self.tokenizer2 = try loadTokenizer(
+            hub: hub, configuration: configuration, vocabulary: .tokenizerVocabulary2,
+            merges: .tokenizerMerges2)
+
+        try super.init(
+            hub: hub, configuration: configuration, dType: dType,
+            diffusionConfiguration: diffusionConfiguration, sampler: sampler)
+    }
+
+    open override func ensureLoaded() {
+        super.ensureLoaded()
+        eval(textEncoder2)
+    }
+
+    func conditionText(text: String, imageCount: Int, cfgWeight: Float, negativeText: String?) -> (
+        MLXArray, MLXArray
+    ) {
+        let tokens1 = tokenize(
+            tokenizer: tokenizer, text: text, negativeText: cfgWeight > 1 ? negativeText : nil)
+        let tokens2 = tokenize(
+            tokenizer: tokenizer2, text: text, negativeText: cfgWeight > 1 ? negativeText : nil)
+
+        let conditioning1 = textEncoder(tokens1)
+        let conditioning2 = textEncoder2(tokens2)
+        var conditioning = concatenated(
+            [
+                conditioning1.hiddenStates.dropLast().last!,
+                conditioning2.hiddenStates.dropLast().last!,
+            ],
+            axis: -1)
+        let pooledConditionng = conditioning2.pooledOutput
+
+        if imageCount > 1 {
+            conditioning = repeated(conditioning, count: imageCount, axis: 0)
+        }
+
+        return (conditioning, pooledConditionng)
+    }
+
+    public func generateLatents(parameters: EvaluateParameters) -> DenoiseIterator {
+        MLXRandom.seed(parameters.seed)
+
+        let (conditioning, pooledConditioning) = conditionText(
+            text: parameters.prompt, imageCount: parameters.imageCount,
+            cfgWeight: parameters.cfgWeight, negativeText: parameters.negativePrompt)
+
+        let textTime = (
+            pooledConditioning,
+            repeated(
+                MLXArray(converting: [512.0, 512, 0, 0, 512, 512]).reshaped(1, -1),
+                count: pooledConditioning.count, axis: 0)
+        )
+
+        let xt = sampler.samplePrior(
+            shape: [parameters.imageCount] + parameters.latentSize + [autoencoder.latentChannels],
+            dType: dType)
+
+        return DenoiseIterator(
+            sd: self, xt: xt, t: sampler.maxTime, conditioning: conditioning,
+            steps: parameters.steps, cfgWeight: parameters.cfgWeight, textTime: textTime)
+    }
+
+    public func generateLatents(image: MLXArray, parameters: EvaluateParameters, strength: Float)
+        -> DenoiseIterator
+    {
+        MLXRandom.seed(parameters.seed)
+
+        // Define the num steps and start step
+        let startStep = Float(sampler.maxTime) * strength
+        let numSteps = Int(Float(parameters.steps) * strength)
+
+        let (conditioning, pooledConditioning) = conditionText(
+            text: parameters.prompt, imageCount: parameters.imageCount,
+            cfgWeight: parameters.cfgWeight, negativeText: parameters.negativePrompt)
+
+        let textTime = (
+            pooledConditioning,
+            repeated(
+                MLXArray(converting: [512.0, 512, 0, 0, 512, 512]).reshaped(1, -1),
+                count: pooledConditioning.count, axis: 0)
+        )
+
+        // Get the latents from the input image and add noise according to the
+        // start time.
+
+        var (x0, _) = autoencoder.encode(image[.newAxis])
+        x0 = broadcast(x0, to: [parameters.imageCount] + x0.shape.dropFirst())
+        let xt = sampler.addNoise(x: x0, t: MLXArray(startStep))
+
+        return DenoiseIterator(
+            sd: self, xt: xt, t: sampler.maxTime, conditioning: conditioning, steps: numSteps,
+            cfgWeight: parameters.cfgWeight, textTime: textTime)
+    }
+}

--- a/Libraries/StableDiffusion/Tokenizer.swift
+++ b/Libraries/StableDiffusion/Tokenizer.swift
@@ -1,0 +1,135 @@
+// Copyright © 2024 Apple Inc.
+
+import Foundation
+
+struct Bigram: Hashable {
+    let a: String
+    let b: String
+
+    init(_ s: String) {
+        let pieces = s.split(separator: " ")
+        precondition(pieces.count == 2, "BPEPair expected two pieces for '\(s)'")
+        self.a = String(pieces[0])
+        self.b = String(pieces[1])
+    }
+
+    init(_ a: String, _ b: String) {
+        self.a = a
+        self.b = b
+    }
+
+    init(_ v: (String, String)) {
+        self.a = v.0
+        self.b = v.1
+    }
+}
+
+/// A CLIP tokenizer.
+///
+/// Ported from:
+///
+/// - https://github.com/ml-explore/mlx-examples/blob/main/stable_diffusion/stable_diffusion/tokenizer.py
+/// - https://github.com/huggingface/transformers/blob/main/src/transformers/models/clip/tokenization_clip.py
+///
+/// Ideally this would be a tokenizer from `swift-transformers` but this is too special purpose to be representable in
+/// what exists there (at time of writing).
+class CLIPTokenizer {
+
+    let pattern =
+        /<\|startoftext\|>|<\|endoftext\|>|'s|'t|'re|'ve|'m|'ll|'d|[\p{L}]+|[\p{N}]|[^\s\p{L}\p{N}]+/
+    let bpeRanks: [Bigram: Int]
+    let vocabulary: [String: Int]
+
+    let bos = "<|startoftext|>"
+    let eos = "<|endoftext|>"
+
+    let bosToken: Int
+    let eosToken: Int
+
+    var cache = [String: [String]]()
+
+    init(merges: [String], vocabulary: [String: Int]) {
+        self.bpeRanks = Dictionary(
+            uniqueKeysWithValues:
+                merges
+                .map { Bigram($0) }
+                .enumerated()
+                .map { ($0.element, $0.offset) })
+
+        self.vocabulary = vocabulary
+        self.cache[bos] = [bos]
+        self.cache[eos] = [eos]
+        self.bosToken = vocabulary[bos]!
+        self.eosToken = vocabulary[eos]!
+    }
+
+    func bpe(text: String) -> [String] {
+        if let result = cache[text] {
+            return result
+        }
+
+        precondition(!text.isEmpty)
+
+        var unigrams = text.dropLast().map { String($0) } + ["\(text.last!)</w>"]
+        var uniqueBigrams = Set(zip(unigrams, unigrams.dropFirst()).map { Bigram($0) })
+
+        // In every iteration try to merge the two most likely bigrams. If none
+        // was merged we are done
+
+        while !uniqueBigrams.isEmpty {
+            let (bigram, _) =
+                uniqueBigrams
+                .map { ($0, bpeRanks[$0] ?? Int.max) }
+                .min { $0.1 < $1.1 }!
+
+            if bpeRanks[bigram] == nil {
+                break
+            }
+
+            var newUnigrams = [String]()
+            var skip = false
+
+            for (a, b) in zip(unigrams, unigrams.dropFirst()) {
+                if skip {
+                    skip = false
+                    continue
+                }
+
+                if Bigram(a, b) == bigram {
+                    newUnigrams.append(a + b)
+                    skip = true
+                } else {
+                    newUnigrams.append(a)
+                }
+            }
+
+            if !skip, let last = unigrams.last {
+                newUnigrams.append(last)
+            }
+
+            unigrams = newUnigrams
+            uniqueBigrams = Set(zip(unigrams, unigrams.dropFirst()).map { Bigram($0) })
+        }
+
+        cache[text] = unigrams
+
+        return unigrams
+    }
+
+    public func tokenize(text: String) -> [Int32] {
+        // Lower case cleanup and split according to self.pat. Hugging Face does
+        // a much more thorough job here but this should suffice for 95% of
+        // cases.
+
+        let clean = text.lowercased().replacing(/\s+/, with: " ")
+        let tokens = clean.matches(of: pattern).map { $0.description }
+
+        // Split the tokens according to the byte-pair merge file
+        let bpeTokens = tokens.flatMap { bpe(text: String($0)) }
+
+        // Map to token ids and return
+        let result = [bosToken] + bpeTokens.compactMap { vocabulary[$0] } + [eosToken]
+
+        return result.map { Int32($0) }
+    }
+}

--- a/Libraries/StableDiffusion/UNet.swift
+++ b/Libraries/StableDiffusion/UNet.swift
@@ -1,0 +1,510 @@
+// Copyright © 2024 Apple Inc.
+
+import Foundation
+import MLX
+import MLXNN
+
+// port of https://github.com/ml-explore/mlx-examples/blob/main/stable_diffusion/stable_diffusion/unet.py
+
+func upsampleNearest(_ x: MLXArray, scale: Int = 2) -> MLXArray {
+    precondition(x.ndim == 4)
+    let (B, H, W, C) = x.shape4
+    var x = broadcast(
+        x[0..., 0..., .newAxis, 0..., .newAxis, 0...], to: [B, H, scale, W, scale, C])
+    x = x.reshaped(B, H * scale, W * scale, C)
+    return x
+}
+
+class TimestepEmbedding: Module, UnaryLayer {
+
+    @ModuleInfo(key: "linear_1") var linear1: Linear
+    @ModuleInfo(key: "linear_2") var linear2: Linear
+
+    init(inputChannels: Int, timeEmbedDimensions: Int) {
+        self._linear1.wrappedValue = Linear(inputChannels, timeEmbedDimensions)
+        self._linear2.wrappedValue = Linear(timeEmbedDimensions, timeEmbedDimensions)
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        var x = linear1(x)
+        x = silu(x)
+        x = linear2(x)
+
+        return x
+    }
+}
+
+class TransformerBlock: Module {
+
+    let norm1: LayerNorm
+    let attn1: MultiHeadAttention
+
+    let norm2: LayerNorm
+    let attn2: MultiHeadAttention
+
+    let norm3: LayerNorm
+    @ModuleInfo var linear1: Linear
+    @ModuleInfo var linear2: Linear
+    @ModuleInfo var linear3: Linear
+
+    init(
+        modelDimensions: Int, numHeads: Int, hiddenDimensions: Int? = nil,
+        memoryDimensions: Int? = nil
+    ) {
+        norm1 = LayerNorm(dimensions: modelDimensions)
+        attn1 = MultiHeadAttention(dimensions: modelDimensions, numHeads: numHeads)
+
+        // we want to self.attn1.out_proj.bias = mx.zeros(model_dims) turn enable the
+        // bias in one of the four Linears attached to attn1.  Since bias is nil we can't
+        // update it so just replace the layer.
+        attn1.update(
+            modules: ModuleChildren(
+                values: ["out_proj": .value(Linear(modelDimensions, modelDimensions, bias: true))]))
+
+        let memoryDimensions = memoryDimensions ?? modelDimensions
+        self.norm2 = LayerNorm(dimensions: modelDimensions)
+        self.attn2 = MultiHeadAttention(
+            dimensions: modelDimensions, numHeads: numHeads, keyInputDimensions: memoryDimensions)
+        attn2.update(
+            modules: ModuleChildren(
+                values: ["out_proj": .value(Linear(modelDimensions, modelDimensions, bias: true))]))
+
+        let hiddenDimensions = hiddenDimensions ?? (4 * modelDimensions)
+        self.norm3 = LayerNorm(dimensions: modelDimensions)
+        self.linear1 = Linear(modelDimensions, hiddenDimensions)
+        self.linear2 = Linear(modelDimensions, hiddenDimensions)
+        self.linear3 = Linear(hiddenDimensions, modelDimensions)
+    }
+
+    func callAsFunction(
+        _ x: MLXArray, memory: MLXArray, attentionMask: MLXArray?, memoryMask: MLXArray?
+    ) -> MLXArray {
+        var x = x
+
+        // self attention
+        var y = norm1(x)
+        y = attn1(y, keys: y, values: y, mask: attentionMask)
+        x = x + y
+
+        // cross attention
+        y = norm2(x)
+        y = attn2(y, keys: memory, values: memory, mask: memoryMask)
+        x = x + y
+
+        // FFN
+        y = norm3(x)
+        let ya = linear1(y)
+        let yb = linear2(y)
+        y = ya * gelu(yb)
+        y = linear3(y)
+        x = x + y
+
+        return x
+    }
+}
+
+/// A transformer model for inputs with 2 spatial dimensions
+class Transformer2D: Module {
+
+    let norm: GroupNorm
+    @ModuleInfo(key: "proj_in") var projectIn: Linear
+    @ModuleInfo(key: "transformer_blocks") var transformerBlocks: [TransformerBlock]
+    @ModuleInfo(key: "proj_out") var projectOut: Linear
+
+    init(
+        inputChannels: Int, modelDimensions: Int, encoderDimensions: Int, numHeads: Int,
+        numLayers: Int, groupCount: Int = 32
+    ) {
+        self.norm = GroupNorm(
+            groupCount: groupCount, dimensions: inputChannels, pytorchCompatible: true)
+        self._projectIn.wrappedValue = Linear(inputChannels, modelDimensions)
+        self._transformerBlocks.wrappedValue = (0 ..< numLayers)
+            .map { _ in
+                TransformerBlock(
+                    modelDimensions: modelDimensions, numHeads: numHeads,
+                    memoryDimensions: encoderDimensions)
+            }
+        self._projectOut.wrappedValue = Linear(modelDimensions, inputChannels)
+    }
+
+    func callAsFunction(
+        _ x: MLXArray, encoderX: MLXArray, attentionMask: MLXArray?, encoderAttentionMask: MLXArray?
+    ) -> MLXArray {
+        let inputX = x
+        let dtype = x.dtype
+        var x = x
+
+        // Perform the input norm and projection
+        let (B, H, W, C) = x.shape4
+        x = norm(x.asType(.float32)).asType(dtype).reshaped(B, -1, C)
+        x = projectIn(x)
+
+        // apply the transformer
+        for block in transformerBlocks {
+            x = block(
+                x, memory: encoderX, attentionMask: attentionMask, memoryMask: encoderAttentionMask)
+        }
+
+        // apply the output projection and reshape
+        x = projectOut(x)
+        x = x.reshaped(B, H, W, C)
+
+        return x + inputX
+    }
+}
+
+class ResnetBlock2D: Module {
+
+    let norm1: GroupNorm
+    let conv1: Conv2d
+
+    @ModuleInfo(key: "time_emb_proj") var timeEmbedProjection: Linear?
+
+    let norm2: GroupNorm
+    let conv2: Conv2d
+
+    @ModuleInfo(key: "conv_shortcut") var convolutionShortcut: Linear?
+
+    init(
+        inputChannels: Int, outputChannels: Int? = nil, groupCount: Int = 32,
+        timeEmbedChannels: Int? = nil
+    ) {
+        let outputChannels = outputChannels ?? inputChannels
+
+        self.norm1 = GroupNorm(
+            groupCount: groupCount, dimensions: inputChannels, pytorchCompatible: true)
+        self.conv1 = Conv2d(
+            inputChannels: inputChannels, outputChannels: outputChannels,
+            kernelSize: 3, stride: 1, padding: 1)
+
+        if let timeEmbedChannels {
+            self._timeEmbedProjection.wrappedValue = Linear(timeEmbedChannels, outputChannels)
+        }
+
+        self.norm2 = GroupNorm(
+            groupCount: groupCount, dimensions: outputChannels, pytorchCompatible: true)
+        self.conv2 = Conv2d(
+            inputChannels: outputChannels, outputChannels: outputChannels,
+            kernelSize: 3, stride: 1, padding: 1)
+
+        if inputChannels != outputChannels {
+            self._convolutionShortcut.wrappedValue = Linear(inputChannels, outputChannels)
+        }
+    }
+
+    func callAsFunction(_ x: MLXArray, timeEmbedding: MLXArray? = nil) -> MLXArray {
+        let dtype = x.dtype
+
+        var y = norm1(x.asType(.float32)).asType(dtype)
+        y = silu(y)
+        y = conv1(y)
+
+        if var timeEmbedding, let timeEmbedProjection {
+            timeEmbedding = timeEmbedProjection(silu(timeEmbedding))
+            y = y + timeEmbedding[0..., .newAxis, .newAxis, 0...]
+        }
+
+        y = norm2(y.asType(.float32)).asType(dtype)
+        y = silu(y)
+        y = conv2(y)
+
+        if let convolutionShortcut {
+            return y + convolutionShortcut(x)
+        } else {
+            return y + x
+        }
+    }
+}
+
+class UNetBlock2D: Module {
+
+    let resnets: [ResnetBlock2D]
+    let attentions: [Transformer2D]?
+    let downsample: Conv2d?
+    let upsample: Conv2d?
+
+    init(
+        inputChannels: Int, outputChannels: Int, timeEmbedChannels: Int,
+        previousOutChannels: Int? = nil, numLayers: Int = 1, transformerLayersPerBlock: Int = 1,
+        numHeads: Int = 8, crossAttentionDimension: Int = 1280, resnetGroups: Int = 32,
+        addDownSample: Bool = true, addUpSample: Bool = true, addCrossAttention: Bool = true
+    ) {
+
+        // Prepare the inputChannelsArray for the resnets
+        let inputChannelsArray: [Int]
+        if let previousOutChannels {
+            let inputChannelsBuild =
+                [previousOutChannels] + Array(repeating: outputChannels, count: numLayers - 1)
+            let resChannelsArray =
+                Array(repeating: outputChannels, count: numLayers - 1) + [inputChannels]
+            inputChannelsArray = zip(inputChannelsBuild, resChannelsArray).map { $0.0 + $0.1 }
+        } else {
+            inputChannelsArray =
+                [inputChannels] + Array(repeating: outputChannels, count: numLayers - 1)
+        }
+
+        // Add resnet blocks that also process the time embedding
+        self.resnets =
+            inputChannelsArray
+            .map { ic in
+                ResnetBlock2D(
+                    inputChannels: ic, outputChannels: outputChannels, groupCount: resnetGroups,
+                    timeEmbedChannels: timeEmbedChannels)
+            }
+
+        // Add optional cross attention layers
+        if addCrossAttention {
+            self.attentions = (0 ..< numLayers)
+                .map { _ in
+                    Transformer2D(
+                        inputChannels: outputChannels, modelDimensions: outputChannels,
+                        encoderDimensions: crossAttentionDimension, numHeads: numHeads,
+                        numLayers: transformerLayersPerBlock)
+                }
+        } else {
+            self.attentions = nil
+        }
+
+        // Add an optional downsampling layer
+        if addDownSample {
+            self.downsample = Conv2d(
+                inputChannels: outputChannels, outputChannels: outputChannels, kernelSize: 3,
+                stride: 2, padding: 1)
+        } else {
+            self.downsample = nil
+        }
+
+        // or upsampling layer
+        if addUpSample {
+            self.upsample = Conv2d(
+                inputChannels: outputChannels, outputChannels: outputChannels, kernelSize: 3,
+                stride: 1, padding: 1)
+        } else {
+            self.upsample = nil
+        }
+    }
+
+    func callAsFunction(
+        _ x: MLXArray, encoderX: MLXArray, timeEmbedding: MLXArray? = nil,
+        attentionMask: MLXArray? = nil, encoderAttentionMask: MLXArray? = nil,
+        residualHiddenStates: [MLXArray]? = nil
+    ) -> (MLXArray, [MLXArray], [MLXArray]) {
+        var x = x
+        var outputStates = [MLXArray]()
+        var residualHiddenStates = residualHiddenStates
+
+        for i in 0 ..< resnets.count {
+            if residualHiddenStates != nil {
+                x = concatenated([x, residualHiddenStates!.removeLast()], axis: -1)
+            }
+
+            x = resnets[i](x, timeEmbedding: timeEmbedding)
+
+            if let attentions {
+                x = attentions[i](
+                    x, encoderX: encoderX, attentionMask: attentionMask,
+                    encoderAttentionMask: encoderAttentionMask)
+            }
+
+            outputStates.append(x)
+        }
+
+        if let downsample {
+            x = downsample(x)
+            outputStates.append(x)
+        }
+
+        if let upsample {
+            x = upsample(upsampleNearest(x))
+            outputStates.append(x)
+        }
+
+        if let residualHiddenStates {
+            return (x, outputStates, residualHiddenStates)
+        } else {
+            return (x, outputStates, [])
+        }
+    }
+}
+
+class UNetModel: Module {
+
+    @ModuleInfo(key: "conv_in") var convIn: Conv2d
+    let timesteps: SinusoidalPositionalEncoding
+    @ModuleInfo(key: "time_embedding") var timeEmbedding: TimestepEmbedding
+
+    @ModuleInfo(key: "addition_embed_type") var addTimeProj: SinusoidalPositionalEncoding?
+    @ModuleInfo(key: "add_embedding") var addEmbedding: TimestepEmbedding?
+
+    @ModuleInfo(key: "down_blocks") var downBlocks: [UNetBlock2D]
+    @ModuleInfo(key: "mid_blocks") var midBlocks: (ResnetBlock2D, Transformer2D, ResnetBlock2D)
+    @ModuleInfo(key: "up_blocks") var upBlocks: [UNetBlock2D]
+
+    @ModuleInfo(key: "conv_norm_out") var convNormOut: GroupNorm
+    @ModuleInfo(key: "conv_out") var convOut: Conv2d
+
+    init(configuration: UNetConfiguration) {
+        let channels0 = configuration.blockOutChannels[0]
+
+        self._convIn.wrappedValue = Conv2d(
+            inputChannels: configuration.inputChannels, outputChannels: channels0,
+            kernelSize: .init(configuration.convolutionInKernel),
+            padding: .init((configuration.convolutionInKernel - 1) / 2))
+
+        self.timesteps = SinusoidalPositionalEncoding(
+            dimensions: channels0,
+            minFrequency: exp(-log(10_000) + 2 * log(10_000) / Float(channels0)),
+            maxFrequency: 1, scale: 1, cosineFirst: true, fullTurns: false)
+
+        self._timeEmbedding.wrappedValue = TimestepEmbedding(
+            inputChannels: channels0, timeEmbedDimensions: channels0 * 4)
+
+        if configuration.additionEmbedType == "text_time",
+            let additionTimeEmbedDimension = configuration.additionTimeEmbedDimension,
+            let projectionClassEmbeddingsInputDimension = configuration
+                .projectionClassEmbeddingsInputDimension
+        {
+            self._addTimeProj.wrappedValue = SinusoidalPositionalEncoding(
+                dimensions: additionTimeEmbedDimension,
+                minFrequency: exp(
+                    -log(10_000) + 2 * log(10_000) / Float(additionTimeEmbedDimension)),
+                maxFrequency: 1,
+                scale: 1, cosineFirst: true, fullTurns: false)
+
+            self._addEmbedding.wrappedValue = TimestepEmbedding(
+                inputChannels: projectionClassEmbeddingsInputDimension,
+                timeEmbedDimensions: channels0 * 4)
+        }
+
+        // make the downsampling blocks
+        let downblockChannels = [channels0] + configuration.blockOutChannels
+        self._downBlocks.wrappedValue = zip(downblockChannels, downblockChannels.dropFirst())
+            .enumerated()
+            .map { (i, pair) in
+                let (inChannels, outChannels) = pair
+                return UNetBlock2D(
+                    inputChannels: inChannels,
+                    outputChannels: outChannels,
+                    timeEmbedChannels: channels0 * 4,
+                    numLayers: configuration.layersPerBlock[i],
+                    transformerLayersPerBlock: configuration.transformerLayersPerBlock[i],
+                    numHeads: configuration.numHeads[i],
+                    crossAttentionDimension: configuration.crossAttentionDimension[i],
+                    resnetGroups: configuration.normNumGroups,
+                    addDownSample: i < configuration.blockOutChannels.count - 1,
+                    addUpSample: false,
+                    addCrossAttention: configuration.downBlockTypes[i].contains("CrossAttn")
+                )
+            }
+
+        // make the middle block
+        let channelsLast = configuration.blockOutChannels.last!
+        self._midBlocks.wrappedValue = (
+            ResnetBlock2D(
+                inputChannels: channelsLast,
+                outputChannels: channelsLast,
+                groupCount: configuration.normNumGroups,
+                timeEmbedChannels: channels0 * 4
+            ),
+            Transformer2D(
+                inputChannels: channelsLast,
+                modelDimensions: channelsLast,
+                encoderDimensions: configuration.crossAttentionDimension.last!,
+                numHeads: configuration.numHeads.last!,
+                numLayers: configuration.transformerLayersPerBlock.last!
+            ),
+            ResnetBlock2D(
+                inputChannels: channelsLast,
+                outputChannels: channelsLast,
+                groupCount: configuration.normNumGroups,
+                timeEmbedChannels: channels0 * 4
+            )
+        )
+
+        // make the upsampling blocks
+        let upblockChannels =
+            [channels0] + configuration.blockOutChannels + [configuration.blockOutChannels.last!]
+        self._upBlocks.wrappedValue =
+            zip(upblockChannels, zip(upblockChannels.dropFirst(), upblockChannels.dropFirst(2)))
+            .enumerated()
+            .reversed()
+            .map { (i, triple) in
+                let (inChannels, (outChannels, prevOutChannels)) = triple
+                return UNetBlock2D(
+                    inputChannels: inChannels,
+                    outputChannels: outChannels,
+                    timeEmbedChannels: channels0 * 4,
+                    previousOutChannels: prevOutChannels,
+                    numLayers: configuration.layersPerBlock[i] + 1,
+                    transformerLayersPerBlock: configuration.transformerLayersPerBlock[i],
+                    numHeads: configuration.numHeads[i],
+                    crossAttentionDimension: configuration.crossAttentionDimension[i],
+                    resnetGroups: configuration.normNumGroups,
+                    addDownSample: false,
+                    addUpSample: i > 0,
+                    addCrossAttention: configuration.upBlockTypes[i].contains("CrossAttn")
+                )
+            }
+
+        self._convNormOut.wrappedValue = GroupNorm(
+            groupCount: configuration.normNumGroups, dimensions: channels0, pytorchCompatible: true)
+        self._convOut.wrappedValue = Conv2d(
+            inputChannels: channels0, outputChannels: configuration.outputChannels,
+            kernelSize: .init(configuration.convolutionOutKernel),
+            padding: .init((configuration.convolutionOutKernel - 1) / 2))
+    }
+
+    func callAsFunction(
+        _ x: MLXArray, timestep: MLXArray, encoderX: MLXArray, attentionMask: MLXArray? = nil,
+        encoderAttentionMask: MLXArray? = nil, textTime: (MLXArray, MLXArray)? = nil
+    ) -> MLXArray {
+        // compute the time embeddings
+        var temb = timesteps(timestep).asType(x.dtype)
+        temb = timeEmbedding(temb)
+
+        // add the extra textTime conditioning
+        if let (textEmbedding, timeIds) = textTime,
+            let addTimeProj, let addEmbedding
+        {
+            var emb = addTimeProj(timeIds).flattened(start: 1).asType(x.dtype)
+            emb = concatenated([textEmbedding, emb], axis: -1)
+            emb = addEmbedding(emb)
+            temb = temb + emb
+        }
+
+        // preprocess the input
+        var x = convIn(x)
+
+        // run the downsampling part of the unet
+        var residuals = [x]
+        for block in self.downBlocks {
+            let res: [MLXArray]
+            (x, res, _) = block(
+                x, encoderX: encoderX, timeEmbedding: temb, attentionMask: attentionMask,
+                encoderAttentionMask: encoderAttentionMask)
+            residuals.append(contentsOf: res)
+        }
+
+        // run the middle part of the unet
+        x = midBlocks.0(x, timeEmbedding: temb)
+        x = midBlocks.1(
+            x, encoderX: encoderX, attentionMask: attentionMask,
+            encoderAttentionMask: encoderAttentionMask)
+        x = midBlocks.2(x, timeEmbedding: temb)
+
+        // run the upsampling part of the unet
+        for block in self.upBlocks {
+            (x, _, residuals) = block(
+                x, encoderX: encoderX, timeEmbedding: temb, attentionMask: attentionMask,
+                encoderAttentionMask: encoderAttentionMask, residualHiddenStates: residuals)
+        }
+
+        // postprocess the output
+        let dtype = x.dtype
+        x = convNormOut(x.asType(.float32)).asType(dtype)
+        x = silu(x)
+        x = convOut(x)
+
+        return x
+    }
+}

--- a/Libraries/StableDiffusion/VAE.swift
+++ b/Libraries/StableDiffusion/VAE.swift
@@ -1,0 +1,319 @@
+// Copyright © 2024 Apple Inc.
+
+import Foundation
+import MLX
+import MLXNN
+import MLXRandom
+
+// port of https://github.com/ml-explore/mlx-examples/blob/main/stable_diffusion/stable_diffusion/vae.py
+
+class Attention: Module, UnaryLayer {
+
+    @ModuleInfo(key: "group_norm") public var groupNorm: GroupNorm
+
+    @ModuleInfo(key: "query_proj") public var queryProjection: Linear
+    @ModuleInfo(key: "key_proj") public var keyProjection: Linear
+    @ModuleInfo(key: "value_proj") public var valueProjection: Linear
+    @ModuleInfo(key: "out_proj") public var outProjection: Linear
+
+    init(dimensions: Int, groupCount: Int = 32) {
+        self._groupNorm.wrappedValue = GroupNorm(
+            groupCount: groupCount, dimensions: dimensions, pytorchCompatible: true)
+
+        self._queryProjection.wrappedValue = Linear(dimensions, dimensions)
+        self._keyProjection.wrappedValue = Linear(dimensions, dimensions)
+        self._valueProjection.wrappedValue = Linear(dimensions, dimensions)
+        self._outProjection.wrappedValue = Linear(dimensions, dimensions)
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        let (B, H, W, C) = x.shape4
+
+        var y = groupNorm(x)
+
+        let queries = queryProjection(y).reshaped(B, H * W, C)
+        let keys = keyProjection(y).reshaped(B, H * W, C)
+        let values = valueProjection(y).reshaped(B, H * W, C)
+
+        let scale = 1 / sqrt(Float(queries.dim(-1)))
+        let scores = (queries * scale).matmul(keys.transposed(0, 2, 1))
+        let attention = softmax(scores, axis: -1)
+
+        y = matmul(attention, values).reshaped(B, H, W, C)
+        y = outProjection(y)
+
+        return x + y
+    }
+}
+
+class EncoderDecoderBlock2D: Module, UnaryLayer {
+
+    let resnets: [ResnetBlock2D]
+    let downsample: Conv2d?
+    let upsample: Conv2d?
+
+    init(
+        inputChannels: Int, outputChannels: Int, numLayers: Int = 1, resnetGroups: Int = 32,
+        addDownSample: Bool = true, addUpSample: Bool = true
+    ) {
+        // Add the resnet blocks
+        self.resnets = (0 ..< numLayers)
+            .map { i in
+                ResnetBlock2D(
+                    inputChannels: i == 0 ? inputChannels : outputChannels,
+                    outputChannels: outputChannels,
+                    groupCount: resnetGroups)
+            }
+
+        // Add an optional downsampling layer
+        if addDownSample {
+            self.downsample = Conv2d(
+                inputChannels: outputChannels, outputChannels: outputChannels, kernelSize: 3,
+                stride: 2, padding: 0)
+        } else {
+            self.downsample = nil
+        }
+
+        // or upsampling layer
+        if addUpSample {
+            self.upsample = Conv2d(
+                inputChannels: outputChannels, outputChannels: outputChannels, kernelSize: 3,
+                stride: 1, padding: 1)
+        } else {
+            self.upsample = nil
+        }
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        var x = x
+
+        for resnet in resnets {
+            x = resnet(x)
+        }
+
+        if let downsample {
+            x = padded(x, widths: [[0, 0], [0, 1], [0, 1], [0, 0]])
+            x = downsample(x)
+        }
+
+        if let upsample {
+            x = upsample(upsampleNearest(x))
+        }
+
+        return x
+    }
+}
+
+/// Implements the encoder side of the Autoencoder
+class VAEncoder: Module, UnaryLayer {
+
+    @ModuleInfo(key: "conv_in") var convIn: Conv2d
+    @ModuleInfo(key: "down_blocks") var downBlocks: [EncoderDecoderBlock2D]
+    @ModuleInfo(key: "mid_blocks") var midBlocks: (ResnetBlock2D, Attention, ResnetBlock2D)
+    @ModuleInfo(key: "conv_norm_out") var convNormOut: GroupNorm
+    @ModuleInfo(key: "conv_out") var convOut: Conv2d
+
+    init(
+        inputChannels: Int, outputChannels: Int, blockOutChannels: [Int] = [64],
+        layersPerBlock: Int = 2, resnetGroups: Int = 32
+    ) {
+        let channels0 = blockOutChannels[0]
+
+        self._convIn.wrappedValue = Conv2d(
+            inputChannels: inputChannels, outputChannels: channels0, kernelSize: 3, stride: 1,
+            padding: 1)
+
+        let downblockChannels = [channels0] + blockOutChannels
+        self._downBlocks.wrappedValue = zip(downblockChannels, downblockChannels.dropFirst())
+            .enumerated()
+            .map { (i, pair) in
+                let (inChannels, outChannels) = pair
+                return EncoderDecoderBlock2D(
+                    inputChannels: inChannels, outputChannels: outChannels,
+                    numLayers: layersPerBlock, resnetGroups: resnetGroups,
+                    addDownSample: i < blockOutChannels.count - 1,
+                    addUpSample: false
+                )
+            }
+
+        let channelsLast = blockOutChannels.last!
+        self._midBlocks.wrappedValue = (
+            ResnetBlock2D(
+                inputChannels: channelsLast,
+                outputChannels: channelsLast,
+                groupCount: resnetGroups
+            ),
+            Attention(dimensions: channelsLast, groupCount: resnetGroups),
+            ResnetBlock2D(
+                inputChannels: channelsLast,
+                outputChannels: channelsLast,
+                groupCount: resnetGroups
+            )
+        )
+
+        self._convNormOut.wrappedValue = GroupNorm(
+            groupCount: resnetGroups, dimensions: channelsLast, pytorchCompatible: true)
+        self._convOut.wrappedValue = Conv2d(
+            inputChannels: channelsLast, outputChannels: outputChannels,
+            kernelSize: 3,
+            padding: 1)
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        var x = convIn(x)
+
+        for l in downBlocks {
+            x = l(x)
+        }
+
+        x = midBlocks.0(x)
+        x = midBlocks.1(x)
+        x = midBlocks.2(x)
+
+        x = convNormOut(x)
+        x = silu(x)
+        x = convOut(x)
+
+        return x
+    }
+}
+
+/// Implements the decoder side of the Autoencoder
+class VADecoder: Module, UnaryLayer {
+
+    @ModuleInfo(key: "conv_in") var convIn: Conv2d
+    @ModuleInfo(key: "mid_blocks") var midBlocks: (ResnetBlock2D, Attention, ResnetBlock2D)
+    @ModuleInfo(key: "up_blocks") var upBlocks: [EncoderDecoderBlock2D]
+    @ModuleInfo(key: "conv_norm_out") var convNormOut: GroupNorm
+    @ModuleInfo(key: "conv_out") var convOut: Conv2d
+
+    init(
+        inputChannels: Int, outputChannels: Int, blockOutChannels: [Int] = [64],
+        layersPerBlock: Int = 2, resnetGroups: Int = 32
+    ) {
+        let channels0 = blockOutChannels[0]
+        let channelsLast = blockOutChannels.last!
+
+        self._convIn.wrappedValue = Conv2d(
+            inputChannels: inputChannels, outputChannels: channelsLast, kernelSize: 3, stride: 1,
+            padding: 1)
+
+        self._midBlocks.wrappedValue = (
+            ResnetBlock2D(
+                inputChannels: channelsLast,
+                outputChannels: channelsLast,
+                groupCount: resnetGroups
+            ),
+            Attention(dimensions: channelsLast, groupCount: resnetGroups),
+            ResnetBlock2D(
+                inputChannels: channelsLast,
+                outputChannels: channelsLast,
+                groupCount: resnetGroups
+            )
+        )
+
+        let channels = [channelsLast] + blockOutChannels.reversed()
+        self._upBlocks.wrappedValue = zip(channels, channels.dropFirst())
+            .enumerated()
+            .map { (i, pair) in
+                let (inChannels, outChannels) = pair
+                return EncoderDecoderBlock2D(
+                    inputChannels: inChannels,
+                    outputChannels: outChannels,
+                    numLayers: layersPerBlock,
+                    resnetGroups: resnetGroups,
+                    addDownSample: false,
+                    addUpSample: i < blockOutChannels.count - 1
+                )
+            }
+
+        self._convNormOut.wrappedValue = GroupNorm(
+            groupCount: resnetGroups, dimensions: channels0, pytorchCompatible: true)
+        self._convOut.wrappedValue = Conv2d(
+            inputChannels: channels0, outputChannels: outputChannels,
+            kernelSize: 3,
+            padding: 1)
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        var x = convIn(x)
+
+        x = midBlocks.0(x)
+        x = midBlocks.1(x)
+        x = midBlocks.2(x)
+
+        for l in upBlocks {
+            x = l(x)
+        }
+
+        x = convNormOut(x)
+        x = silu(x)
+        x = convOut(x)
+
+        return x
+    }
+}
+
+/// The autoencoder that allows us to perform diffusion in the latent space
+class Autoencoder: Module {
+
+    let latentChannels: Int
+    let scalingFactor: Float
+    let encoder: VAEncoder
+    let decoder: VADecoder
+
+    @ModuleInfo(key: "quant_proj") public var quantProjection: Linear
+    @ModuleInfo(key: "post_quant_proj") public var postQuantProjection: Linear
+
+    init(configuration: AutoencoderConfiguration) {
+        self.latentChannels = configuration.latentChannelsIn
+        self.scalingFactor = configuration.scalingFactor
+        self.encoder = VAEncoder(
+            inputChannels: configuration.inputChannels,
+            outputChannels: configuration.latentChannelsOut,
+            blockOutChannels: configuration.blockOutChannels,
+            layersPerBlock: configuration.layersPerBlock,
+            resnetGroups: configuration.normNumGroups)
+        self.decoder = VADecoder(
+            inputChannels: configuration.latentChannelsIn,
+            outputChannels: configuration.outputChannels,
+            blockOutChannels: configuration.blockOutChannels,
+            layersPerBlock: configuration.layersPerBlock + 1,
+            resnetGroups: configuration.normNumGroups)
+
+        self._quantProjection.wrappedValue = Linear(
+            configuration.latentChannelsIn, configuration.latentChannelsOut)
+        self._postQuantProjection.wrappedValue = Linear(
+            configuration.latentChannelsIn, configuration.latentChannelsIn)
+    }
+
+    func decode(_ z: MLXArray) -> MLXArray {
+        let z = z / scalingFactor
+        return decoder(postQuantProjection(z))
+    }
+
+    func encode(_ x: MLXArray) -> (MLXArray, MLXArray) {
+        var x = encoder(x)
+        x = quantProjection(x)
+        var (mean, logvar) = x.split(axis: -1)
+        mean = mean * scalingFactor
+        logvar = logvar + 2 * log(scalingFactor)
+
+        return (mean, logvar)
+    }
+
+    struct Result {
+        let xHat: MLXArray
+        let z: MLXArray
+        let mean: MLXArray
+        let logvar: MLXArray
+    }
+
+    func callAsFunction(_ x: MLXArray, key: MLXArray? = nil) -> Result {
+        let (mean, logvar) = encode(x)
+        let z = MLXRandom.normal(mean.shape, key: key) * exp(0.5 * logvar) + mean
+        let xHat = decode(z)
+
+        return Result(xHat: xHat, z: z, mean: mean, logvar: logvar)
+    }
+}

--- a/Package.swift
+++ b/Package.swift
@@ -54,5 +54,17 @@ let package = Package(
                 "MNIST.h",
             ]
         ),
+        .target(
+            name: "StableDiffusion",
+            dependencies: [
+                .product(name: "MLX", package: "mlx-swift"),
+                .product(name: "MLXNN", package: "mlx-swift"),
+                .product(name: "MLXRandom", package: "mlx-swift"),
+            ],
+            path: "Libraries/StableDiffusion",
+            exclude: [
+                "README.md"
+            ]
+        ),
     ]
 )

--- a/README.md
+++ b/README.md
@@ -13,10 +13,17 @@ Example [MLX Swift](https://github.com/ml-explore/mlx-swift) programs.
 - [LinearModelTraining](Tools/LinearModelTraining/README.md): An example that
   trains a simple linear model.
 
+- [StableDiffusionExample](Applications/StableDiffusionExample/README.md): An 
+  example that runs on both iOS and macOS that downloads a stable diffusion model
+  from Hugging Face and  and generates an image from a given prompt. 
+
 - [llm-tool](Tools/llm-tool/README.md): A command line tool for generating text
   using a variety of LLMs available on the Hugging Face hub.
 
-- [mnist-tool](Tools/mnist-tool/README.md): A command line tool for training
+- [image-tool](Tools/image-tool/README.md): A command line tool for generating images
+  using a stable diffusion model from Hugging Face.
+
+- [mnist-tool](Tools/mnist-tool/README.md): A command line tool for training a
   a LeNet on MNIST.
   
 ## Running
@@ -34,7 +41,8 @@ See also:
 
 ## Installation of MLXLLM and MLXMNIST libraries
 
-The MLXLLM and MLXMNIST libraries in the example repo are available as Swift Packages.
+The MLXLLM, MLXMNIST and StableDiffusion libraries in the example repo are available
+as Swift Packages.
 
 
 Add the following dependency to your Package.swift

--- a/Tools/image-tool/Arguments.swift
+++ b/Tools/image-tool/Arguments.swift
@@ -1,0 +1,100 @@
+// Copyright © 2024 Apple Inc.
+
+import ArgumentParser
+import Foundation
+import MLX
+
+#if swift(>=6.0)
+    /// Extension to allow URL command line arguments.
+    extension URL: @retroactive ExpressibleByArgument {
+        public init?(argument: String) {
+            if argument.contains("://") {
+                self.init(string: argument)
+            } else {
+                self.init(filePath: argument)
+            }
+        }
+    }
+#else
+    /// Extension to allow URL command line arguments.
+    extension URL: ExpressibleByArgument {
+        public init?(argument: String) {
+            if argument.contains("://") {
+                self.init(string: argument)
+            } else {
+                self.init(filePath: argument)
+            }
+        }
+    }
+#endif
+
+/// Argument package for adjusting and reporting memory use.
+struct MemoryArguments: ParsableArguments, Sendable {
+
+    @Flag(name: .long, help: "Show memory stats")
+    var memoryStats = false
+
+    @Option(name: .long, help: "Maximum cache size in M")
+    var cacheSize = 1024
+
+    @Option(name: .long, help: "Maximum memory size in M")
+    var memorySize: Int?
+
+    var startMemory: GPU.Snapshot?
+
+    mutating func start<L>(_ load: () async throws -> L) async throws -> L {
+        GPU.set(cacheLimit: cacheSize * 1024 * 1024)
+
+        if let memorySize {
+            GPU.set(memoryLimit: memorySize * 1024 * 1024)
+        }
+
+        let result = try await load()
+        startMemory = GPU.snapshot()
+
+        return result
+    }
+
+    mutating func start() {
+        GPU.set(cacheLimit: cacheSize * 1024 * 1024)
+
+        if let memorySize {
+            GPU.set(memoryLimit: memorySize * 1024 * 1024)
+        }
+
+        startMemory = GPU.snapshot()
+    }
+
+    func reportCurrent() {
+        if memoryStats {
+            let memory = GPU.snapshot()
+            print(memory.description)
+        }
+    }
+
+    func reportMemoryStatistics() {
+        if memoryStats, let startMemory {
+            let endMemory = GPU.snapshot()
+
+            print("=======")
+            print("Memory size: \(GPU.memoryLimit / 1024)K")
+            print("Cache size:  \(GPU.cacheLimit / 1024)K")
+
+            print("")
+            print("=======")
+            print("Starting memory")
+            print(startMemory.description)
+
+            print("")
+            print("=======")
+            print("Ending memory")
+            print(endMemory.description)
+
+            print("")
+            print("=======")
+            print("Growth")
+            print(startMemory.delta(endMemory).description)
+
+        }
+    }
+}

--- a/Tools/image-tool/ImageTool.swift
+++ b/Tools/image-tool/ImageTool.swift
@@ -1,0 +1,278 @@
+// Copyright © 2024 Apple Inc.
+
+import ArgumentParser
+import Foundation
+import MLX
+import Progress
+import StableDiffusion
+
+@main
+struct ImageTool: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        abstract: "Command line tool for working with images and MLX",
+        subcommands: [StableDiffusionTool.self])
+}
+
+struct StableDiffusionTool: AsyncParsableCommand {
+
+    static let configuration = CommandConfiguration(
+        commandName: "sd",
+        abstract: "Stable diffusion related commands",
+        subcommands: [TextToImageCommand.self, ImageToImageCommand.self]
+    )
+}
+
+#if swift(>=6.0)
+    extension StableDiffusionConfiguration.Preset: @retroactive ExpressibleByArgument {}
+#else
+    extension StableDiffusionConfiguration.Preset: ExpressibleByArgument {}
+#endif
+
+struct ModelArguments: ParsableArguments, Sendable {
+
+    @Option(name: .long, help: "stable diffusion model")
+    var model: StableDiffusionConfiguration.Preset = .sdxlTurbo
+
+    @Flag(name: .long, inversion: .prefixedNo, help: "Disable float16 conversion")
+    var float16 = true
+
+    @Flag(name: .long, help: "Enable quantization")
+    var quantize = false
+
+    var loadConfiguration: LoadConfiguration {
+        LoadConfiguration(float16: float16, quantize: quantize)
+    }
+
+    func download() async throws -> StableDiffusionConfiguration {
+        let configuration = model.configuration
+
+        var progressBar: ProgressBar?
+        try await configuration.download { progress in
+            if progressBar == nil {
+                let complete = progress.fractionCompleted
+                if complete < 0.99 {
+                    progressBar = ProgressBar(count: 1000)
+                    if complete > 0 {
+                        print("Resuming download (\(Int(complete * 100))% complete)")
+                    } else {
+                        print("Downloading")
+                    }
+                    print()
+                }
+            }
+
+            let complete = Int(progress.fractionCompleted * 1000)
+            progressBar?.setValue(complete)
+        }
+
+        return configuration
+    }
+}
+
+/// Command line arguments for controlling generation of images
+struct GenerateArguments: ParsableArguments, Sendable {
+
+    @Option(name: .shortAndLong, help: "The message to be processed by the model")
+    var prompt = "purple cow on the moon"
+
+    @Option(name: .shortAndLong, help: "Negative prompt (requires cfg to be > 1)")
+    var negativePrompt = ""
+
+    @Option(name: .long, help: "cfg weight")
+    var cfg: Float?
+
+    @Option(name: .long, help: "number of images")
+    var imageCount: Int = 1
+
+    @Option(name: .long, help: "decoding batch size")
+    var batchSize: Int = 1
+
+    @Option(name: .long, help: "latent width (output size is 8x this value)")
+    var latentWidth: Int = 64
+
+    @Option(name: .long, help: "latent height (output size is 8x this value)")
+    var latentHeight: Int = 64
+
+    @Option(name: .long, help: "number of rows of images in the output")
+    var rows: Int = 1
+
+    @Option(name: .long, help: "number of steps")
+    var steps: Int?
+
+    @Option(name: .long, help: "The PRNG seed")
+    var seed: UInt64?
+
+    func evaluateParameters(configuration: StableDiffusionConfiguration) -> EvaluateParameters {
+        var parameters = configuration.defaultParameters()
+        parameters.prompt = prompt
+        parameters.negativePrompt = negativePrompt
+        if let cfg {
+            parameters.cfgWeight = cfg
+        }
+        parameters.imageCount = imageCount
+        parameters.decodingBatchSize = batchSize
+        parameters.latentSize = [latentHeight, latentWidth]
+        if let steps {
+            parameters.steps = steps
+        }
+        if let seed {
+            parameters.seed = seed
+        }
+        print("using seed: \(parameters.seed)")
+        return parameters
+    }
+
+}
+
+func makeGrid(images: [MLXArray], rows: Int) -> MLXArray {
+    var x = concatenated(images, axis: 0)
+    x = padded(x, widths: [[0, 0], [8, 8], [8, 8], [0, 0]])
+    let (B, H, W, C) = x.shape4
+    x = x.reshaped(rows, B / rows, H, W, C).transposed(0, 2, 1, 3, 4)
+    x = x.reshaped(rows * H, B / rows * W, C)
+    x = (x * 255).asType(.uint8)
+    return x
+}
+
+struct TextToImageCommand: AsyncParsableCommand {
+
+    static let configuration = CommandConfiguration(
+        commandName: "text",
+        abstract: "Text to image command"
+    )
+
+    @Option(name: .long, help: "output image")
+    var output = URL(filePath: "/tmp/out.png")
+
+    @OptionGroup var model: ModelArguments
+    @OptionGroup var memory: MemoryArguments
+    @OptionGroup var generate: GenerateArguments
+
+    mutating func generateLatents(configuration: StableDiffusionConfiguration) throws -> (
+        EvaluateParameters, ImageDecoder, MLXArray
+    ) {
+        // download and prepare the model
+        guard
+            let generator = try configuration.textToImageGenerator(
+                configuration: model.loadConfiguration)
+        else {
+            fatalError("Unable to produce TextToImageGenerator from \(configuration.id)")
+        }
+
+        generator.ensureLoaded()
+        memory.start()
+
+        // generate the latents -- these are the iterations for generating
+        // the output image.  this is just generating the evaluation graph
+        let parameters = generate.evaluateParameters(configuration: configuration)
+        let latents = generator.generateLatents(parameters: parameters)
+
+        // evaluate the latents (evalue the graph) and keep the last value generated
+        var lastXt: MLXArray!
+        for xt in Progress(latents) {
+            eval(xt)
+            lastXt = xt
+        }
+
+        return (parameters, generator.detachedDecoder(), lastXt)
+    }
+
+    @MainActor
+    mutating func run() async throws {
+        let configuration = try await model.download()
+
+        let (parameters, decoder, xt) = try generateLatents(configuration: configuration)
+
+        var decoded = [MLXArray]()
+        for i in Progress(
+            stride(from: 0, to: parameters.imageCount, by: parameters.decodingBatchSize))
+        {
+            let image = decoder(xt[i ..< i + parameters.decodingBatchSize])
+            eval(image)
+            decoded.append(image)
+        }
+
+        let grid = makeGrid(images: decoded, rows: generate.rows)
+        try Image(grid).save(url: output)
+    }
+}
+
+struct ImageToImageCommand: AsyncParsableCommand {
+
+    static let configuration = CommandConfiguration(
+        commandName: "image",
+        abstract: "Image to image command"
+    )
+
+    @Option(name: .long, help: "input image")
+    var input: URL
+
+    @Option(name: .long, help: "maximum edge of the input image -- scale to fit this size")
+    var maxEdge: Int = 1024
+
+    @Option(name: .long, help: "output image")
+    var output = URL(filePath: "/tmp/out.png")
+
+    @Option(name: .long, help: "noise strength")
+    var strength: Float = 0.9
+
+    @OptionGroup var model: ModelArguments
+    @OptionGroup var memory: MemoryArguments
+    @OptionGroup var generate: GenerateArguments
+
+    mutating func generateLatents(configuration: StableDiffusionConfiguration) throws -> (
+        EvaluateParameters, ImageDecoder, MLXArray
+    ) {
+
+        let image = try Image(url: self.input, maximumEdge: maxEdge)
+        let input = (image.data.asType(.float32) / 255) * 2 - 1
+
+        guard
+            let generator = try configuration.imageToImageGenerator(
+                configuration: model.loadConfiguration)
+        else {
+            fatalError("Unable to produce TextToImageGenerator from \(configuration.id)")
+        }
+
+        generator.ensureLoaded()
+        memory.start()
+
+        // adjust the steps based on the strength
+        if Int(Float(generate.evaluateParameters(configuration: configuration).steps) * strength)
+            < 1
+        {
+            generate.steps = Int(ceil(1 / strength))
+        }
+
+        let parameters = generate.evaluateParameters(configuration: configuration)
+        let latents = generator.generateLatents(
+            image: input, parameters: parameters, strength: strength)
+
+        var lastXt: MLXArray!
+        for xt in Progress(latents) {
+            eval(xt)
+            lastXt = xt
+        }
+
+        return (parameters, generator.detachedDecoder(), lastXt)
+    }
+
+    @MainActor
+    mutating func run() async throws {
+        let configuration = try await model.download()
+
+        let (parameters, decoder, xt) = try generateLatents(configuration: configuration)
+
+        var decoded = [MLXArray]()
+        for i in Progress(
+            stride(from: 0, to: parameters.imageCount, by: parameters.decodingBatchSize))
+        {
+            let image = decoder(xt[i ..< i + parameters.decodingBatchSize])
+            eval(image)
+            decoded.append(image)
+        }
+
+        let grid = makeGrid(images: decoded, rows: generate.rows)
+        try Image(grid).save(url: output)
+    }
+}

--- a/mlx-swift-examples.xcodeproj/project.pbxproj
+++ b/mlx-swift-examples.xcodeproj/project.pbxproj
@@ -40,6 +40,31 @@
 		C36BEFB52BBDEAD8002D4AFE /* LoraCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = C36BEFB32BBDEA69002D4AFE /* LoraCommands.swift */; };
 		C36BEFB82BBDED51002D4AFE /* Arguments.swift in Sources */ = {isa = PBXBuildFile; fileRef = C36BEFB62BBDECBC002D4AFE /* Arguments.swift */; };
 		C36BEFBB2BBF02CC002D4AFE /* Lora+Data.swift in Sources */ = {isa = PBXBuildFile; fileRef = C36BEFBA2BBF02CC002D4AFE /* Lora+Data.swift */; };
+		C36BEFCA2BC09953002D4AFE /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = C36BEFC92BC09953002D4AFE /* Configuration.swift */; };
+		C36BEFCC2BC09E53002D4AFE /* Sampler.swift in Sources */ = {isa = PBXBuildFile; fileRef = C36BEFCB2BC09E53002D4AFE /* Sampler.swift */; };
+		C36BEFCE2BC0A194002D4AFE /* MLX in Frameworks */ = {isa = PBXBuildFile; productRef = C36BEFCD2BC0A194002D4AFE /* MLX */; };
+		C36BEFD02BC0A194002D4AFE /* MLXNN in Frameworks */ = {isa = PBXBuildFile; productRef = C36BEFCF2BC0A194002D4AFE /* MLXNN */; };
+		C36BEFD22BC0A194002D4AFE /* MLXRandom in Frameworks */ = {isa = PBXBuildFile; productRef = C36BEFD12BC0A194002D4AFE /* MLXRandom */; };
+		C36BEFD42BC0B4A9002D4AFE /* Clip.swift in Sources */ = {isa = PBXBuildFile; fileRef = C36BEFD32BC0B4A9002D4AFE /* Clip.swift */; };
+		C36BEFD82BC0BD9B002D4AFE /* VAE.swift in Sources */ = {isa = PBXBuildFile; fileRef = C36BEFD72BC0BD9B002D4AFE /* VAE.swift */; };
+		C36BEFDA2BC0BDDC002D4AFE /* UNet.swift in Sources */ = {isa = PBXBuildFile; fileRef = C36BEFD92BC0BDDC002D4AFE /* UNet.swift */; };
+		C36BEFE32BC32988002D4AFE /* ImageTool.swift in Sources */ = {isa = PBXBuildFile; fileRef = C36BEFE22BC32988002D4AFE /* ImageTool.swift */; };
+		C36BEFE72BC329AB002D4AFE /* StableDiffusion.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C36BEFC22BC098F3002D4AFE /* StableDiffusion.framework */; };
+		C36BEFE82BC329AB002D4AFE /* StableDiffusion.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = C36BEFC22BC098F3002D4AFE /* StableDiffusion.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		C36BEFEF2BC329C5002D4AFE /* ArgumentParser in Frameworks */ = {isa = PBXBuildFile; productRef = C36BEFEE2BC329C5002D4AFE /* ArgumentParser */; };
+		C36BEFF22BC32A9A002D4AFE /* Progress in Frameworks */ = {isa = PBXBuildFile; productRef = C36BEFF12BC32A9A002D4AFE /* Progress */; };
+		C36BEFF42BC349FA002D4AFE /* Load.swift in Sources */ = {isa = PBXBuildFile; fileRef = C36BEFF32BC349FA002D4AFE /* Load.swift */; };
+		C36BEFF62BC34A46002D4AFE /* StableDiffusion.swift in Sources */ = {isa = PBXBuildFile; fileRef = C36BEFF52BC34A46002D4AFE /* StableDiffusion.swift */; };
+		C36BEFF82BC59CE1002D4AFE /* Tokenizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = C36BEFF72BC59CE1002D4AFE /* Tokenizer.swift */; };
+		C36BEFFA2BC5B996002D4AFE /* Transformers in Frameworks */ = {isa = PBXBuildFile; productRef = C36BEFF92BC5B996002D4AFE /* Transformers */; };
+		C36BEFFC2BC5BA79002D4AFE /* Image.swift in Sources */ = {isa = PBXBuildFile; fileRef = C36BEFFB2BC5BA79002D4AFE /* Image.swift */; };
+		C36BF0042BC5CE55002D4AFE /* StableDiffusionExampleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = C36BF0032BC5CE55002D4AFE /* StableDiffusionExampleApp.swift */; };
+		C36BF0062BC5CE55002D4AFE /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C36BF0052BC5CE55002D4AFE /* ContentView.swift */; };
+		C36BF0082BC5CE56002D4AFE /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C36BF0072BC5CE56002D4AFE /* Assets.xcassets */; };
+		C36BF00C2BC5CE56002D4AFE /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C36BF00B2BC5CE56002D4AFE /* Preview Assets.xcassets */; };
+		C36BF0102BC5CF17002D4AFE /* StableDiffusion.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C36BEFC22BC098F3002D4AFE /* StableDiffusion.framework */; };
+		C36BF0112BC5CF17002D4AFE /* StableDiffusion.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = C36BEFC22BC098F3002D4AFE /* StableDiffusion.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		C36BF0352BC70F11002D4AFE /* Arguments.swift in Sources */ = {isa = PBXBuildFile; fileRef = C36BF0342BC70F11002D4AFE /* Arguments.swift */; };
 		C373EB732C792DD1004E201E /* KVCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = C373EB722C792DD1004E201E /* KVCache.swift */; };
 		C38935C82B869C7A0037B833 /* LLM.h in Headers */ = {isa = PBXBuildFile; fileRef = C38935C72B869C7A0037B833 /* LLM.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C38935CC2B869C870037B833 /* Llama.swift in Sources */ = {isa = PBXBuildFile; fileRef = C34E48EE2B696E6500FCB841 /* Llama.swift */; };
@@ -99,6 +124,20 @@
 			proxyType = 1;
 			remoteGlobalIDString = C34E490C2B69A92900FCB841;
 			remoteInfo = MNIST;
+		};
+		C36BEFE92BC329AB002D4AFE /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C39273682B60697700368D5D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = C36BEFC12BC098F3002D4AFE;
+			remoteInfo = StableDiffusion;
+		};
+		C36BF0122BC5CF17002D4AFE /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C39273682B60697700368D5D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = C36BEFC12BC098F3002D4AFE;
+			remoteInfo = StableDiffusion;
 		};
 		C38935D92B869CCD0037B833 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -160,6 +199,37 @@
 			dstSubfolderSpec = 10;
 			files = (
 				C34E492B2B6A028800FCB841 /* MNIST.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C36BEFDE2BC32988002D4AFE /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = /usr/share/man/man1/;
+			dstSubfolderSpec = 0;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 1;
+		};
+		C36BEFEB2BC329AB002D4AFE /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				C36BEFE82BC329AB002D4AFE /* StableDiffusion.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C36BF0142BC5CF17002D4AFE /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				C36BF0112BC5CF17002D4AFE /* StableDiffusion.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -256,6 +326,25 @@
 		C36BEFB32BBDEA69002D4AFE /* LoraCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoraCommands.swift; sourceTree = "<group>"; };
 		C36BEFB62BBDECBC002D4AFE /* Arguments.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Arguments.swift; sourceTree = "<group>"; };
 		C36BEFBA2BBF02CC002D4AFE /* Lora+Data.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Lora+Data.swift"; sourceTree = "<group>"; };
+		C36BEFC22BC098F3002D4AFE /* StableDiffusion.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = StableDiffusion.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		C36BEFC92BC09953002D4AFE /* Configuration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Configuration.swift; sourceTree = "<group>"; };
+		C36BEFCB2BC09E53002D4AFE /* Sampler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sampler.swift; sourceTree = "<group>"; };
+		C36BEFD32BC0B4A9002D4AFE /* Clip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Clip.swift; sourceTree = "<group>"; };
+		C36BEFD72BC0BD9B002D4AFE /* VAE.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VAE.swift; sourceTree = "<group>"; };
+		C36BEFD92BC0BDDC002D4AFE /* UNet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UNet.swift; sourceTree = "<group>"; };
+		C36BEFE02BC32988002D4AFE /* image-tool */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = "image-tool"; sourceTree = BUILT_PRODUCTS_DIR; };
+		C36BEFE22BC32988002D4AFE /* ImageTool.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageTool.swift; sourceTree = "<group>"; };
+		C36BEFF32BC349FA002D4AFE /* Load.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Load.swift; sourceTree = "<group>"; };
+		C36BEFF52BC34A46002D4AFE /* StableDiffusion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StableDiffusion.swift; sourceTree = "<group>"; };
+		C36BEFF72BC59CE1002D4AFE /* Tokenizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tokenizer.swift; sourceTree = "<group>"; };
+		C36BEFFB2BC5BA79002D4AFE /* Image.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Image.swift; sourceTree = "<group>"; };
+		C36BF0012BC5CE55002D4AFE /* StableDiffusionExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = StableDiffusionExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		C36BF0032BC5CE55002D4AFE /* StableDiffusionExampleApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StableDiffusionExampleApp.swift; sourceTree = "<group>"; };
+		C36BF0052BC5CE55002D4AFE /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		C36BF0072BC5CE56002D4AFE /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		C36BF0092BC5CE56002D4AFE /* StableDiffusionExample.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = StableDiffusionExample.entitlements; sourceTree = "<group>"; };
+		C36BF00B2BC5CE56002D4AFE /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		C36BF0342BC70F11002D4AFE /* Arguments.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Arguments.swift; sourceTree = "<group>"; };
 		C373EB722C792DD1004E201E /* KVCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KVCache.swift; sourceTree = "<group>"; };
 		C38935C52B869C7A0037B833 /* LLM.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = LLM.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C38935C72B869C7A0037B833 /* LLM.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LLM.h; sourceTree = "<group>"; };
@@ -285,6 +374,8 @@
 		C3A8B3F22B92A2A90002EFB8 /* ContentView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		C3C3240B2B6CA689007D2D9A /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		C3C3240C2B6CA792007D2D9A /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
+		C3D573052C40701E00857A35 /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
+		C3D573062C40702D00857A35 /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		C3E786AA2B8D1AEC0004D037 /* Evaluate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Evaluate.swift; sourceTree = "<group>"; };
 		C3E786AC2B8D4AF50004D037 /* Tokenizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tokenizer.swift; sourceTree = "<group>"; };
 		F24B08392BAF1A65008C8D19 /* Cohere.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Cohere.swift; sourceTree = "<group>"; };
@@ -329,6 +420,35 @@
 				C3FBCB2D2B8520E80007E490 /* MLXOptimizers in Frameworks */,
 				C34E492A2B6A028800FCB841 /* MNIST.framework in Frameworks */,
 				C34E49292B6A028100FCB841 /* ArgumentParser in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C36BEFBF2BC098F3002D4AFE /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C36BEFD02BC0A194002D4AFE /* MLXNN in Frameworks */,
+				C36BEFD22BC0A194002D4AFE /* MLXRandom in Frameworks */,
+				C36BEFFA2BC5B996002D4AFE /* Transformers in Frameworks */,
+				C36BEFCE2BC0A194002D4AFE /* MLX in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C36BEFDD2BC32988002D4AFE /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C36BEFEF2BC329C5002D4AFE /* ArgumentParser in Frameworks */,
+				C36BEFF22BC32A9A002D4AFE /* Progress in Frameworks */,
+				C36BEFE72BC329AB002D4AFE /* StableDiffusion.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C36BEFFE2BC5CE55002D4AFE /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C36BF0102BC5CF17002D4AFE /* StableDiffusion.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -471,6 +591,53 @@
 			path = "mnist-tool";
 			sourceTree = "<group>";
 		};
+		C36BEFC32BC098F3002D4AFE /* StableDiffusion */ = {
+			isa = PBXGroup;
+			children = (
+				C3D573062C40702D00857A35 /* README.md */,
+				C36BEFD32BC0B4A9002D4AFE /* Clip.swift */,
+				C36BEFC92BC09953002D4AFE /* Configuration.swift */,
+				C36BEFCB2BC09E53002D4AFE /* Sampler.swift */,
+				C36BEFD72BC0BD9B002D4AFE /* VAE.swift */,
+				C36BEFD92BC0BDDC002D4AFE /* UNet.swift */,
+				C36BEFF32BC349FA002D4AFE /* Load.swift */,
+				C36BEFF52BC34A46002D4AFE /* StableDiffusion.swift */,
+				C36BEFF72BC59CE1002D4AFE /* Tokenizer.swift */,
+				C36BEFFB2BC5BA79002D4AFE /* Image.swift */,
+			);
+			path = StableDiffusion;
+			sourceTree = "<group>";
+		};
+		C36BEFE12BC32988002D4AFE /* image-tool */ = {
+			isa = PBXGroup;
+			children = (
+				C36BEFE22BC32988002D4AFE /* ImageTool.swift */,
+				C36BF0342BC70F11002D4AFE /* Arguments.swift */,
+			);
+			path = "image-tool";
+			sourceTree = "<group>";
+		};
+		C36BF0022BC5CE55002D4AFE /* StableDiffusionExample */ = {
+			isa = PBXGroup;
+			children = (
+				C3D573052C40701E00857A35 /* README.md */,
+				C36BF0032BC5CE55002D4AFE /* StableDiffusionExampleApp.swift */,
+				C36BF0052BC5CE55002D4AFE /* ContentView.swift */,
+				C36BF0072BC5CE56002D4AFE /* Assets.xcassets */,
+				C36BF0092BC5CE56002D4AFE /* StableDiffusionExample.entitlements */,
+				C36BF00A2BC5CE56002D4AFE /* Preview Content */,
+			);
+			path = StableDiffusionExample;
+			sourceTree = "<group>";
+		};
+		C36BF00A2BC5CE56002D4AFE /* Preview Content */ = {
+			isa = PBXGroup;
+			children = (
+				C36BF00B2BC5CE56002D4AFE /* Preview Assets.xcassets */,
+			);
+			path = "Preview Content";
+			sourceTree = "<group>";
+		};
 		C38935C62B869C7A0037B833 /* LLM */ = {
 			isa = PBXGroup;
 			children = (
@@ -525,6 +692,9 @@
 				C3A8B3B22B9295090002EFB8 /* MNISTTrainer.app */,
 				C3A8B3DC2B92A29E0002EFB8 /* LLMEval.app */,
 				C3056BAB2BCD97B700A31D04 /* LoRATrainingExample.app */,
+				C36BEFC22BC098F3002D4AFE /* StableDiffusion.framework */,
+				C36BEFE02BC32988002D4AFE /* image-tool */,
+				C36BF0012BC5CE55002D4AFE /* StableDiffusionExample.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -547,6 +717,7 @@
 		C39273812B606A7400368D5D /* Tools */ = {
 			isa = PBXGroup;
 			children = (
+				C36BEFE12BC32988002D4AFE /* image-tool */,
 				C3288D742B6D9313009FF608 /* LinearModelTraining */,
 				C34E49222B6A026F00FCB841 /* mnist-tool */,
 				C34E48F32B696F0B00FCB841 /* llm-tool */,
@@ -558,6 +729,7 @@
 		C39273822B606A9200368D5D /* Libraries */ = {
 			isa = PBXGroup;
 			children = (
+				C36BEFC32BC098F3002D4AFE /* StableDiffusion */,
 				C38935C62B869C7A0037B833 /* LLM */,
 				C34E490E2B69A92900FCB841 /* MNIST */,
 			);
@@ -568,6 +740,7 @@
 			isa = PBXGroup;
 			children = (
 				C3056BAC2BCD97B700A31D04 /* LoRATrainingExample */,
+				C36BF0022BC5CE55002D4AFE /* StableDiffusionExample */,
 				C3A8B3EB2B92A2A90002EFB8 /* LLMEval */,
 				C3A8B3C12B92951E0002EFB8 /* MNISTTrainer */,
 			);
@@ -627,6 +800,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				C34E49102B69A92900FCB841 /* MNIST.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C36BEFBD2BC098F3002D4AFE /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -731,6 +911,72 @@
 			productName = "mnist-tool";
 			productReference = C34E49212B6A026F00FCB841 /* mnist-tool */;
 			productType = "com.apple.product-type.tool";
+		};
+		C36BEFC12BC098F3002D4AFE /* StableDiffusion */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = C36BEFC82BC098F3002D4AFE /* Build configuration list for PBXNativeTarget "StableDiffusion" */;
+			buildPhases = (
+				C36BEFBD2BC098F3002D4AFE /* Headers */,
+				C36BEFBE2BC098F3002D4AFE /* Sources */,
+				C36BEFBF2BC098F3002D4AFE /* Frameworks */,
+				C36BEFC02BC098F3002D4AFE /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = StableDiffusion;
+			packageProductDependencies = (
+				C36BEFCD2BC0A194002D4AFE /* MLX */,
+				C36BEFCF2BC0A194002D4AFE /* MLXNN */,
+				C36BEFD12BC0A194002D4AFE /* MLXRandom */,
+				C36BEFF92BC5B996002D4AFE /* Transformers */,
+			);
+			productName = Image;
+			productReference = C36BEFC22BC098F3002D4AFE /* StableDiffusion.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		C36BEFDF2BC32988002D4AFE /* image-tool */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = C36BEFE42BC32988002D4AFE /* Build configuration list for PBXNativeTarget "image-tool" */;
+			buildPhases = (
+				C36BEFDC2BC32988002D4AFE /* Sources */,
+				C36BEFDD2BC32988002D4AFE /* Frameworks */,
+				C36BEFDE2BC32988002D4AFE /* CopyFiles */,
+				C36BEFEB2BC329AB002D4AFE /* Embed Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				C36BEFEA2BC329AB002D4AFE /* PBXTargetDependency */,
+			);
+			name = "image-tool";
+			packageProductDependencies = (
+				C36BEFEE2BC329C5002D4AFE /* ArgumentParser */,
+				C36BEFF12BC32A9A002D4AFE /* Progress */,
+			);
+			productName = "image-tool";
+			productReference = C36BEFE02BC32988002D4AFE /* image-tool */;
+			productType = "com.apple.product-type.tool";
+		};
+		C36BF0002BC5CE55002D4AFE /* StableDiffusionExample */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = C36BF00D2BC5CE56002D4AFE /* Build configuration list for PBXNativeTarget "StableDiffusionExample" */;
+			buildPhases = (
+				C36BEFFD2BC5CE55002D4AFE /* Sources */,
+				C36BEFFE2BC5CE55002D4AFE /* Frameworks */,
+				C36BEFFF2BC5CE55002D4AFE /* Resources */,
+				C36BF0142BC5CF17002D4AFE /* Embed Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				C36BF0132BC5CF17002D4AFE /* PBXTargetDependency */,
+			);
+			name = StableDiffusionExample;
+			productName = StableDiffusionEval;
+			productReference = C36BF0012BC5CE55002D4AFE /* StableDiffusionExample.app */;
+			productType = "com.apple.product-type.application";
 		};
 		C38935C42B869C7A0037B833 /* LLM */ = {
 			isa = PBXNativeTarget;
@@ -866,6 +1112,16 @@
 					C34E49202B6A026F00FCB841 = {
 						CreatedOnToolsVersion = 15.0.1;
 					};
+					C36BEFC12BC098F3002D4AFE = {
+						CreatedOnToolsVersion = 15.3;
+						LastSwiftMigration = 1530;
+					};
+					C36BEFDF2BC32988002D4AFE = {
+						CreatedOnToolsVersion = 15.3;
+					};
+					C36BF0002BC5CE55002D4AFE = {
+						CreatedOnToolsVersion = 15.3;
+					};
 					C38935C42B869C7A0037B833 = {
 						CreatedOnToolsVersion = 15.2;
 					};
@@ -898,6 +1154,7 @@
 				C3FBCB1F2B8520B00007E490 /* XCRemoteSwiftPackageReference "mlx-swift" */,
 				C38935BB2B866BFA0037B833 /* XCRemoteSwiftPackageReference "swift-transformers" */,
 				81695B3F2BA373D300F260D8 /* XCRemoteSwiftPackageReference "swift-markdown-ui" */,
+				C36BEFF02BC32A8C002D4AFE /* XCRemoteSwiftPackageReference "Progress" */,
 			);
 			productRefGroup = C39273752B606A0A00368D5D /* Products */;
 			projectDirPath = "";
@@ -906,12 +1163,15 @@
 				C39273732B606A0A00368D5D /* Tutorial */,
 				C397C58A2B62C6A9004B084D /* llm-tool */,
 				C38935C42B869C7A0037B833 /* LLM */,
+				C36BEFC12BC098F3002D4AFE /* StableDiffusion */,
 				C34E49202B6A026F00FCB841 /* mnist-tool */,
 				C34E490C2B69A92900FCB841 /* MNIST */,
 				C3288D722B6D9313009FF608 /* LinearModelTraining */,
 				C3A8B3B12B9295090002EFB8 /* MNISTTrainer */,
 				C3A8B3DB2B92A29D0002EFB8 /* LLMEval */,
 				C3056BAA2BCD97B700A31D04 /* LoRATrainingExample */,
+				C36BEFDF2BC32988002D4AFE /* image-tool */,
+				C36BF0002BC5CE55002D4AFE /* StableDiffusionExample */,
 			);
 		};
 /* End PBXProject section */
@@ -933,6 +1193,22 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C36BEFC02BC098F3002D4AFE /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C36BEFFF2BC5CE55002D4AFE /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C36BF00C2BC5CE56002D4AFE /* Preview Assets.xcassets in Resources */,
+				C36BF0082BC5CE56002D4AFE /* Assets.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -996,6 +1272,40 @@
 			buildActionMask = 2147483647;
 			files = (
 				C34E49242B6A026F00FCB841 /* MNISTTool.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C36BEFBE2BC098F3002D4AFE /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C36BEFD82BC0BD9B002D4AFE /* VAE.swift in Sources */,
+				C36BEFFC2BC5BA79002D4AFE /* Image.swift in Sources */,
+				C36BEFF42BC349FA002D4AFE /* Load.swift in Sources */,
+				C36BEFCC2BC09E53002D4AFE /* Sampler.swift in Sources */,
+				C36BEFD42BC0B4A9002D4AFE /* Clip.swift in Sources */,
+				C36BEFCA2BC09953002D4AFE /* Configuration.swift in Sources */,
+				C36BEFF82BC59CE1002D4AFE /* Tokenizer.swift in Sources */,
+				C36BEFDA2BC0BDDC002D4AFE /* UNet.swift in Sources */,
+				C36BEFF62BC34A46002D4AFE /* StableDiffusion.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C36BEFDC2BC32988002D4AFE /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C36BF0352BC70F11002D4AFE /* Arguments.swift in Sources */,
+				C36BEFE32BC32988002D4AFE /* ImageTool.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C36BEFFD2BC5CE55002D4AFE /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C36BF0062BC5CE55002D4AFE /* ContentView.swift in Sources */,
+				C36BF0042BC5CE55002D4AFE /* StableDiffusionExampleApp.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1075,6 +1385,16 @@
 			isa = PBXTargetDependency;
 			target = C34E490C2B69A92900FCB841 /* MNIST */;
 			targetProxy = C34E492C2B6A028800FCB841 /* PBXContainerItemProxy */;
+		};
+		C36BEFEA2BC329AB002D4AFE /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = C36BEFC12BC098F3002D4AFE /* StableDiffusion */;
+			targetProxy = C36BEFE92BC329AB002D4AFE /* PBXContainerItemProxy */;
+		};
+		C36BF0132BC5CF17002D4AFE /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = C36BEFC12BC098F3002D4AFE /* StableDiffusion */;
+			targetProxy = C36BF0122BC5CF17002D4AFE /* PBXContainerItemProxy */;
 		};
 		C38935DA2B869CCD0037B833 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -1710,6 +2030,492 @@
 			};
 			name = Release;
 		};
+		C36BEFC62BC098F3002D4AFE /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_MODULE_VERIFIER = YES;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = (
+					"@executable_path/../Frameworks",
+					"@loader_path/Frameworks",
+				);
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MARKETING_VERSION = 1.0;
+				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = mlx.Image;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SDKROOT = auto;
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx xros xrsimulator";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_STRICT_CONCURRENCY = complete;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2,7";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		C36BEFC72BC098F3002D4AFE /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_MODULE_VERIFIER = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = (
+					"@executable_path/../Frameworks",
+					"@loader_path/Frameworks",
+				);
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MARKETING_VERSION = 1.0;
+				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = mlx.Image;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SDKROOT = auto;
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx xros xrsimulator";
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_STRICT_CONCURRENCY = complete;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2,7";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		C36BEFE52BC32988002D4AFE /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MACOSX_DEPLOYMENT_TARGET = 14.4;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_STRICT_CONCURRENCY = complete;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		C36BEFE62BC32988002D4AFE /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MACOSX_DEPLOYMENT_TARGET = 14.4;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_STRICT_CONCURRENCY = complete;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		C36BF00E2BC5CE56002D4AFE /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_ENTITLEMENTS = Applications/StableDiffusionExample/StableDiffusionExample.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_ASSET_PATHS = "\"Applications/StableDiffusionExample/Preview Content\"";
+				DEVELOPMENT_TEAM = "";
+				ENABLE_PREVIEWS = YES;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphoneos*]" = UIStatusBarStyleDefault;
+				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphonesimulator*]" = UIStatusBarStyleDefault;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 17.2;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
+				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MACOSX_DEPLOYMENT_TARGET = 14.2;
+				MARKETING_VERSION = 1.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = mlx.StableDiffusionExample;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx xros xrsimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_STRICT_CONCURRENCY = complete;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2,7";
+			};
+			name = Debug;
+		};
+		C36BF00F2BC5CE56002D4AFE /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_ENTITLEMENTS = Applications/StableDiffusionExample/StableDiffusionExample.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_ASSET_PATHS = "\"Applications/StableDiffusionExample/Preview Content\"";
+				DEVELOPMENT_TEAM = "";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_PREVIEWS = YES;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 2;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphoneos*]" = UIStatusBarStyleDefault;
+				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphonesimulator*]" = UIStatusBarStyleDefault;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 17.2;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
+				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MACOSX_DEPLOYMENT_TARGET = 14.2;
+				MARKETING_VERSION = 1.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = mlx.StableDiffusionExample;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx xros xrsimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_STRICT_CONCURRENCY = complete;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2,7";
+			};
+			name = Release;
+		};
 		C38935CA2B869C7A0037B833 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -1897,6 +2703,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD)";
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_COMMA = YES;
@@ -1934,6 +2741,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD)";
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_COMMA = YES;
@@ -2618,6 +3426,33 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
+		C36BEFC82BC098F3002D4AFE /* Build configuration list for PBXNativeTarget "StableDiffusion" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C36BEFC62BC098F3002D4AFE /* Debug */,
+				C36BEFC72BC098F3002D4AFE /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		C36BEFE42BC32988002D4AFE /* Build configuration list for PBXNativeTarget "image-tool" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C36BEFE52BC32988002D4AFE /* Debug */,
+				C36BEFE62BC32988002D4AFE /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		C36BF00D2BC5CE56002D4AFE /* Build configuration list for PBXNativeTarget "StableDiffusionExample" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C36BF00E2BC5CE56002D4AFE /* Debug */,
+				C36BF00F2BC5CE56002D4AFE /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		C38935C92B869C7A0037B833 /* Build configuration list for PBXNativeTarget "LLM" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -2691,6 +3526,14 @@
 				version = 6.0.1;
 			};
 		};
+		C36BEFF02BC32A8C002D4AFE /* XCRemoteSwiftPackageReference "Progress" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/jkandzi/Progress.swift";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.4.0;
+			};
+		};
 		C38935BB2B866BFA0037B833 /* XCRemoteSwiftPackageReference "swift-transformers" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/huggingface/swift-transformers";
@@ -2742,6 +3585,36 @@
 			isa = XCSwiftPackageProductDependency;
 			package = C3FBCB1F2B8520B00007E490 /* XCRemoteSwiftPackageReference "mlx-swift" */;
 			productName = MLXOptimizers;
+		};
+		C36BEFCD2BC0A194002D4AFE /* MLX */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C3FBCB1F2B8520B00007E490 /* XCRemoteSwiftPackageReference "mlx-swift" */;
+			productName = MLX;
+		};
+		C36BEFCF2BC0A194002D4AFE /* MLXNN */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C3FBCB1F2B8520B00007E490 /* XCRemoteSwiftPackageReference "mlx-swift" */;
+			productName = MLXNN;
+		};
+		C36BEFD12BC0A194002D4AFE /* MLXRandom */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C3FBCB1F2B8520B00007E490 /* XCRemoteSwiftPackageReference "mlx-swift" */;
+			productName = MLXRandom;
+		};
+		C36BEFEE2BC329C5002D4AFE /* ArgumentParser */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C392736E2B60699100368D5D /* XCRemoteSwiftPackageReference "swift-argument-parser" */;
+			productName = ArgumentParser;
+		};
+		C36BEFF12BC32A9A002D4AFE /* Progress */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C36BEFF02BC32A8C002D4AFE /* XCRemoteSwiftPackageReference "Progress" */;
+			productName = Progress;
+		};
+		C36BEFF92BC5B996002D4AFE /* Transformers */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C38935BB2B866BFA0037B833 /* XCRemoteSwiftPackageReference "swift-transformers" */;
+			productName = Transformers;
 		};
 		C38935CF2B869CC40037B833 /* MLX */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/mlx-swift-examples.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/mlx-swift-examples.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "c553d4a0e8610e1ac348b9a2ae25cf60a97387e744154297089876b441e5896b",
+  "originHash" : "6750e2209d3e8ec777b601627ba31d0346e487e6b7d748ce241ec3d5623411a2",
   "pins" : [
     {
       "identity" : "gzipswift",
@@ -26,6 +26,15 @@
       "state" : {
         "revision" : "7aff8d1b31148d32c5933d75557d42f6323ee3d1",
         "version" : "6.0.0"
+      }
+    },
+    {
+      "identity" : "progress.swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jkandzi/Progress.swift",
+      "state" : {
+        "revision" : "fed6598735d7982058690acf8f52a0a5fdaeb3e0",
+        "version" : "0.4.0"
       }
     },
     {


### PR DESCRIPTION
- based on https://github.com/ml-explore/mlx-examples/tree/main/stable_diffusion

- example code for these two models
- https://huggingface.co/stabilityai/sdxl-turbo
- https://huggingface.co/stabilityai/stable-diffusion-2-1

- command line tool example for text-to-image
- command line tool example for image-to-image
- example application for same

A screenshot of `StableDiffusionExample` running on macOS:

<img width="1088" alt="image" src="https://github.com/user-attachments/assets/af889869-7218-49cb-bd49-ace4453aad42">

StableDiffusion requires roughly 7G of available RAM to run, though it has a "conserveMemory" mode that will run on an 8G or 6G iOS device with considerable performance degradation:

- it will load and unload portions of the model as it runs
    - this means that running a second time will require the application to re-load the weights
- it will use quantized Linear layers (lower quality)
- it will use a single pass rather than 2 passes (SDXL)

Users who wish to tune or adjust this can example `ContentView.swift` in the `StableDiffusionExample` and look at the `conserveMemory` property.

```swift
        self.conserveMemory = MLX.GPU.memoryLimit < 8 * 1024 * 1024 * 1024
```

On computers with > 8G of memory, once the weights are loaded, subsequent image generations are relatively quick.

In the command line tool there are a number of parameters -- you can easily adjust the output size to make a panorama:

```
./mlx-run --debug image-tool sd text --prompt "an alien planet with a prominent volcano and large moon in the sky" --latent-width 256 --latent-height 96
```