### PR TITLE
make sure config.json is downloaded

### DIFF
--- a/Libraries/LLM/Load.swift
+++ b/Libraries/LLM/Load.swift
@@ -20,7 +20,7 @@ func prepareModelDirectory(
         case .id(let id):
             // download the model weights
             let repo = Hub.Repo(id: id)
-            let modelFiles = ["*.safetensors"]
+            let modelFiles = ["*.safetensors", "config.json"]
             return try await hub.snapshot(
                 from: repo, matching: modelFiles, progressHandler: progressHandler)
 


### PR DESCRIPTION
- with recent swift 6 refactor the tokenizer and model loading sequence was changed
- the tokenizer load also downloaded the config.json
- make sure the model download code asks for this too

Replacement for #119 per feedback from @awni 