### PR TITLE
Add LLama 3.2 1B and 3B lightweight models descriptions

### DIFF
--- a/Libraries/LLM/Models.swift
+++ b/Libraries/LLM/Models.swift
@@ -228,7 +228,7 @@ extension ModelConfiguration {
         prompt in
         "<|begin_of_text|><|start_header_id|>system<|end_header_id|>\nYou are a helpful assistant<|eot_id|>\n<|start_header_id|>user<|end_header_id|>\n\(prompt)<|eot_id|>\n<|start_header_id|>assistant<|end_header_id|>"
     }
-    
+
     public static let llama3_2_1B_4bit = ModelConfiguration(
         id: "mlx-community/Llama-3.2-1B-Instruct-4bit",
         defaultPrompt: "What is the difference between a fruit and a vegetable?"
@@ -236,11 +236,11 @@ extension ModelConfiguration {
         prompt in
         "<|begin_of_text|><|start_header_id|>system<|end_header_id|>\nYou are a helpful assistant<|eot_id|>\n<|start_header_id|>user<|end_header_id|>\n\(prompt)<|eot_id|>\n<|start_header_id|>assistant<|end_header_id|>"
     }
-    
+
     public static let llama3_2_3B_4bit = ModelConfiguration(
         id: "mlx-community/Llama-3.2-3B-Instruct-4bit",
         defaultPrompt: "What is the difference between a fruit and a vegetable?"
-        ) {
+    ) {
         prompt in
         "<|begin_of_text|><|start_header_id|>system<|end_header_id|>\nYou are a helpful assistant<|eot_id|>\n<|start_header_id|>user<|end_header_id|>\n\(prompt)<|eot_id|>\n<|start_header_id|>assistant<|end_header_id|>"
     }

--- a/Libraries/LLM/Models.swift
+++ b/Libraries/LLM/Models.swift
@@ -228,6 +228,22 @@ extension ModelConfiguration {
         prompt in
         "<|begin_of_text|><|start_header_id|>system<|end_header_id|>\nYou are a helpful assistant<|eot_id|>\n<|start_header_id|>user<|end_header_id|>\n\(prompt)<|eot_id|>\n<|start_header_id|>assistant<|end_header_id|>"
     }
+    
+    public static let llama3_2_1B_4bit = ModelConfiguration(
+        id: "mlx-community/Llama-3.2-1B-Instruct-4bit",
+        defaultPrompt: "What is the difference between a fruit and a vegetable?"
+    ) {
+        prompt in
+        "<|begin_of_text|><|start_header_id|>system<|end_header_id|>\nYou are a helpful assistant<|eot_id|>\n<|start_header_id|>user<|end_header_id|>\n\(prompt)<|eot_id|>\n<|start_header_id|>assistant<|end_header_id|>"
+    }
+    
+    public static let llama3_2_3B_4bit = ModelConfiguration(
+        id: "mlx-community/Llama-3.2-3B-Instruct-4bit",
+        defaultPrompt: "What is the difference between a fruit and a vegetable?"
+        ) {
+        prompt in
+        "<|begin_of_text|><|start_header_id|>system<|end_header_id|>\nYou are a helpful assistant<|eot_id|>\n<|start_header_id|>user<|end_header_id|>\n\(prompt)<|eot_id|>\n<|start_header_id|>assistant<|end_header_id|>"
+    }
 
     private enum BootstrapState: Sendable {
         case idle
@@ -245,6 +261,8 @@ extension ModelConfiguration {
             bootstrapState = .bootstrapping
             register(configurations: [
                 llama3_1_8B_4bit,
+                llama3_2_1B_4bit,
+                llama3_2_3B_4bit,
                 mistralNeMo4bit,
                 smolLM_135M_4bit,
                 mistral7B4bit,

--- a/mlx-swift-examples.xcodeproj/project.pbxproj
+++ b/mlx-swift-examples.xcodeproj/project.pbxproj
@@ -3543,7 +3543,7 @@
 			repositoryURL = "https://github.com/huggingface/swift-transformers";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 0.1.9;
+				minimumVersion = 0.1.12;
 			};
 		};
 		C392736E2B60699100368D5D /* XCRemoteSwiftPackageReference "swift-argument-parser" */ = {


### PR DESCRIPTION
This adds ModelConfigurations for the new [Llama 3.2](https://www.llama.com) lightweight models with 1B and 3B parameters, and bumps the Xcode project dependency on `swift-transformers` so that it can use the new `Sequence` processor, required for Llama v3.2.

Llama 3.2 introduces two new lightweight versions with 1B and 3B parameters, which speeds the inference considerably when compared to the 3.1 8B version (on my M1 16Gb, it goes from 12 tokens/sec to 66 tokens/sec on the 1B model).