### PR TITLE
use updated url

### DIFF
--- a/Applications/MNISTTrainer/MNISTTrainer-Info.plist
+++ b/Applications/MNISTTrainer/MNISTTrainer-Info.plist
@@ -1,17 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict>
-	<key>NSAppTransportSecurity</key>
-	<dict>
-		<key>NSExceptionDomains</key>
-		<dict>
-			<key>yann.lecun.com</key>
-			<dict>
-				<key>NSExceptionAllowsInsecureHTTPLoads</key>
-				<true/>
-			</dict>
-		</dict>
-	</dict>
-</dict>
+<dict/>
 </plist>

--- a/Libraries/MNIST/Files.swift
+++ b/Libraries/MNIST/Files.swift
@@ -36,7 +36,7 @@ struct LoadInfo: Sendable {
     let convert: @Sendable (MLXArray) -> MLXArray
 }
 
-let baseURL = URL(string: "http://yann.lecun.com/exdb/mnist/")!
+let baseURL = URL(string: "https://raw.githubusercontent.com/fgnt/mnist/master/")!
 
 private let files = [
     FileKind(.training, .images): LoadInfo(


### PR DESCRIPTION
previously we were using an http url and needed an ATS security exception.  At some point that redirected to an https url, but that certificate is expired.  This switches to a new https url -- the same one used by the python example code.