### PR TITLE
fix: add StableDiffusion to package products

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,6 +13,9 @@ let package = Package(
         .library(
             name: "MNIST",
             targets: ["MLXMNIST"]),
+        .library(
+            name: "StableDiffusion",
+            targets: ["StableDiffusion"]),
     ],
     dependencies: [
         .package(url: "https://github.com/ml-explore/mlx-swift", from: "0.16.1"),


### PR DESCRIPTION
Add StableDiffusion library declaration in Package.swift products array to make it visible and importable in Xcode projects.