### PR TITLE
Fix SuScaledRotaryEmbedding for Phi-3 mini 128k

### DIFF
--- a/Libraries/LLM/Models.swift
+++ b/Libraries/LLM/Models.swift
@@ -134,6 +134,12 @@ extension ModelConfiguration {
         extraEOSTokens: ["<|end|>"]
     )
 
+    public static let phi3_mini_128k_4bit = ModelConfiguration(
+        id: "mlx-community/Phi-3-mini-128k-instruct-4bit",
+        defaultPrompt: "What is the gravity on Mars and the moon?",
+        extraEOSTokens: ["<|end|>"]
+    )
+
     public static let phi3_5MoE = ModelConfiguration(
         id: "mlx-community/Phi-3.5-MoE-instruct-4bit",
         defaultPrompt: "What is the gravity on Mars and the moon?",

--- a/Libraries/LLM/SuScaledRotaryEmbedding.swift
+++ b/Libraries/LLM/SuScaledRotaryEmbedding.swift
@@ -45,10 +45,10 @@ public class SuScaledRotaryEmbedding: Module {
             self.scale * x,
             dimensions: x.shape.last!,
             traditional: false,
-            base: self.base,  // TODO: After updating to MLX 0.17.0, use `nil`
+            base: nil,
             scale: 1.0,
-            offset: offset
-                // TODO: After updating to MLX 0.17.0, pass `self._freqs` to `freqs`
+            offset: offset,
+            freqs: self._freqs
         )
     }
 }

--- a/Libraries/LLM/SuScaledRotaryEmbedding.swift
+++ b/Libraries/LLM/SuScaledRotaryEmbedding.swift
@@ -30,7 +30,18 @@ public class SuScaledRotaryEmbedding: Module {
         let exponent =
             MLXArray(stride(from: 0, to: dimensions, by: 2)).asType(.float32) / Float(dimensions)
         let freqs = MLX.pow(MLXArray(base), exponent)
-        self._freqs = MLXArray(longFactor).asType(.float32) * freqs
+
+        let longFactorArray = MLXArray(longFactor).asType(.float32)
+        if longFactorArray.size == 1 {
+            // If longFactor is a single value, broadcast it
+            self._freqs = MLXArray(longFactor[0]) * freqs
+        } else {
+            // If longFactor is an array, it should match the frequency dimensions
+            precondition(
+                longFactorArray.size == freqs.size,
+                "longFactor size must match frequency dimensions")
+            self._freqs = longFactorArray * freqs
+        }
 
         self.scale =
             longMScale


### PR DESCRIPTION
I've verified that this works with Phi-3 mini 128k 4-bit and Phi-3.5 mini 4-bit. I think this should fix https://github.com/ml-explore/mlx-swift-examples/issues/92 and https://github.com/ml-explore/mlx-swift-examples/issues/127.