### PR TITLE
Add Embedders/Encoders support.

### DIFF
--- a/Libraries/Embedders/Bert.swift
+++ b/Libraries/Embedders/Bert.swift
@@ -1,0 +1,334 @@
+// Copyright © 2024 Apple Inc.
+
+import MLX
+import MLXFast
+import MLXNN
+
+extension MLXArray {
+    public static func arange(_ size: Int) -> MLXArray {
+        return MLXArray(Array(0 ..< size))
+    }
+}
+
+private class BertEmbedding: Module {
+
+    let typeVocabularySize: Int
+    @ModuleInfo(key: "word_embeddings") var wordEmbeddings: Embedding
+    @ModuleInfo(key: "norm") var norm: LayerNorm
+    @ModuleInfo(key: "token_type_embeddings") var tokenTypeEmbeddings: Embedding?
+    @ModuleInfo(key: "position_embeddings") var positionEmbeddings: Embedding
+
+    init(_ config: BertConfiguration) {
+        typeVocabularySize = config.typeVocabularySize
+        _wordEmbeddings.wrappedValue = Embedding(
+            embeddingCount: config.vocabularySize, dimensions: config.embedDim)
+        _norm.wrappedValue = LayerNorm(
+            dimensions: config.embedDim, eps: config.layerNormEps)
+        if config.typeVocabularySize > 0 {
+            _tokenTypeEmbeddings.wrappedValue = Embedding(
+                embeddingCount: config.typeVocabularySize,
+                dimensions: config.embedDim)
+        }
+        _positionEmbeddings.wrappedValue = Embedding(
+            embeddingCount: config.maxPositionEmbeddings,
+            dimensions: config.embedDim)
+
+    }
+
+    func callAsFunction(
+        _ inputIds: MLXArray,
+        positionIds: MLXArray? = nil,
+        tokenTypeIds: MLXArray? = nil
+    ) -> MLXArray {
+        let posIds = positionIds ?? broadcast(MLXArray.arange(inputIds.dim(1)), to: inputIds.shape)
+        let words = wordEmbeddings(inputIds) + positionEmbeddings(posIds)
+        if let tokenTypeIds, let tokenTypeEmbeddings {
+            words += tokenTypeEmbeddings(tokenTypeIds)
+        }
+        return norm(words)
+    }
+}
+
+private class TransformerBlock: Module {
+    let attention: MultiHeadAttention
+    @ModuleInfo(key: "ln1") var preLayerNorm: LayerNorm
+    @ModuleInfo(key: "ln2") var postLayerNorm: LayerNorm
+    @ModuleInfo(key: "linear1") var up: Linear
+    @ModuleInfo(key: "linear2") var down: Linear
+
+    init(_ config: BertConfiguration) {
+        attention = MultiHeadAttention(
+            dimensions: config.embedDim, numHeads: config.numHeads, bias: true)
+        _preLayerNorm.wrappedValue = LayerNorm(
+            dimensions: config.embedDim, eps: config.layerNormEps)
+        _postLayerNorm.wrappedValue = LayerNorm(
+            dimensions: config.embedDim, eps: config.layerNormEps)
+        _up.wrappedValue = Linear(config.embedDim, config.interDim)
+        _down.wrappedValue = Linear(config.interDim, config.embedDim)
+    }
+
+    func callAsFunction(_ inputs: MLXArray, mask: MLXArray? = nil) -> MLXArray {
+        let attentionOut = attention(inputs, keys: inputs, values: inputs, mask: mask)
+        let preNorm = preLayerNorm(inputs + attentionOut)
+
+        let mlpOut = down(gelu(up(preNorm)))
+        return postLayerNorm(mlpOut + preNorm)
+    }
+}
+
+private class Encoder: Module {
+    let layers: [TransformerBlock]
+    init(_ config: BertConfiguration) {
+        precondition(config.vocabularySize > 0)
+        layers = (0 ..< config.numLayers).map { _ in TransformerBlock(config) }
+    }
+    func callAsFunction(_ inputs: MLXArray, attentionMask: MLXArray? = nil) -> MLXArray {
+        var outputs = inputs
+        for layer in layers {
+            outputs = layer(outputs, mask: attentionMask)
+        }
+        return outputs
+    }
+}
+
+private class LMHead: Module {
+    @ModuleInfo(key: "dense") var dense: Linear
+    @ModuleInfo(key: "ln") var layerNorm: LayerNorm
+    @ModuleInfo(key: "decoder") var decoder: Linear
+
+    init(_ config: BertConfiguration) {
+        _dense.wrappedValue = Linear(
+            config.embedDim, config.embedDim, bias: true)
+        _layerNorm.wrappedValue = LayerNorm(
+            dimensions: config.embedDim, eps: config.layerNormEps)
+        _decoder.wrappedValue = Linear(
+            config.embedDim, config.vocabularySize, bias: true)
+    }
+    func callAsFunction(_ inputs: MLXArray) -> MLXArray {
+        return decoder(layerNorm(silu(dense(inputs))))
+    }
+}
+
+public class BertModel: Module, EmbeddingModel {
+    @ModuleInfo(key: "lm_head") fileprivate var lmHead: LMHead?
+    @ModuleInfo(key: "embeddings") fileprivate var embedder: BertEmbedding
+    let pooler: Linear?
+    fileprivate let encoder: Encoder
+    public var vocabularySize: Int
+
+    public init(
+        _ config: BertConfiguration, lmHead: Bool = false
+    ) {
+        precondition(config.vocabularySize > 0)
+        vocabularySize = config.vocabularySize
+        encoder = Encoder(config)
+        _embedder.wrappedValue = BertEmbedding(config)
+
+        if lmHead {
+            _lmHead.wrappedValue = LMHead(config)
+            self.pooler = nil
+        } else {
+            pooler = Linear(config.embedDim, config.embedDim)
+            _lmHead.wrappedValue = nil
+        }
+    }
+
+    public func callAsFunction(
+        _ inputs: MLXArray, positionIds: MLXArray? = nil, tokenTypeIds: MLXArray? = nil,
+        attentionMask: MLXArray? = nil
+    )
+        -> EmbeddingModelOutput
+    {
+        var inp = inputs
+        if inp.ndim == 1 {
+            inp = inp.reshaped(1, -1)
+        }
+        var mask = attentionMask
+        if mask != nil {
+            mask = mask!.asType(embedder.wordEmbeddings.weight.dtype).expandedDimensions(axes: [
+                1, 2,
+            ]).log()
+        }
+        let outputs = encoder(
+            embedder(inp, positionIds: positionIds, tokenTypeIds: tokenTypeIds),
+            attentionMask: mask)
+        if let lmHead {
+            return EmbeddingModelOutput(hiddenStates: lmHead(outputs), pooledOutput: nil)
+        } else {
+            return EmbeddingModelOutput(
+                hiddenStates: outputs, pooledOutput: tanh(pooler!(outputs[0..., 0])))
+        }
+    }
+
+    public func sanitize(weights: [String: MLXArray]) -> [String: MLXArray] {
+        weights.reduce(into: [:]) { result, item in
+            var key = item.key.replacingOccurrences(of: ".layer.", with: ".layers.")
+            key = key.replacingOccurrences(of: ".self.key.", with: ".key_proj.")
+            key = key.replacingOccurrences(of: ".self.query.", with: ".query_proj.")
+            key = key.replacingOccurrences(of: ".self.value.", with: ".value_proj.")
+            key = key.replacingOccurrences(
+                of: ".attention.output.dense.", with: ".attention.out_proj.")
+            key = key.replacingOccurrences(of: ".attention.output.LayerNorm.", with: ".ln1.")
+            key = key.replacingOccurrences(of: ".output.LayerNorm.", with: ".ln2.")
+            key = key.replacingOccurrences(of: ".intermediate.dense.", with: ".linear1.")
+            key = key.replacingOccurrences(of: ".output.dense.", with: ".linear2.")
+            key = key.replacingOccurrences(of: ".LayerNorm.", with: ".norm.")
+            key = key.replacingOccurrences(of: "pooler.dense.", with: "pooler.")
+            key = key.replacingOccurrences(
+                of:
+                    "cls.predictions.transform.dense.",
+                with: "lm_head.dense.")
+            key = key.replacingOccurrences(
+                of:
+                    "cls.predictions.transform.LayerNorm.",
+                with: "lm_head.ln.")
+            key = key.replacingOccurrences(
+                of:
+                    "cls.predictions.decoder",
+                with: "lm_head.decoder")
+            key = key.replacingOccurrences(
+                of: "cls.predictions.transform.norm.weight",
+                with: "lm_head.ln.weight")
+            key = key.replacingOccurrences(
+                of: "cls.predictions.transform.norm.bias",
+                with: "lm_head.ln.bias")
+            key = key.replacingOccurrences(of: "cls.predictions.bias", with: "lm_head.decoder.bias")
+            key = key.replacingOccurrences(of: "bert.", with: "")
+            result[key] = item.value
+        }.filter { key, _ in key != "embeddings.position_ids" }
+    }
+}
+
+public class DistilBertModel: BertModel {
+    public override func sanitize(weights: [String: MLXArray]) -> [String: MLXArray] {
+        weights.reduce(into: [:]) { result, item in
+            var key = item.key.replacingOccurrences(of: ".layer.", with: ".layers.")
+            key = key.replacingOccurrences(of: "transformer.", with: "encoder.")
+            key = key.replacingOccurrences(of: "embeddings.LayerNorm", with: "embeddings.norm")
+            key = key.replacingOccurrences(of: ".attention.q_lin.", with: ".attention.query_proj.")
+            key = key.replacingOccurrences(of: ".attention.k_lin.", with: ".attention.key_proj.")
+            key = key.replacingOccurrences(of: ".attention.v_lin.", with: ".attention.value_proj.")
+            key = key.replacingOccurrences(of: ".attention.out_lin.", with: ".attention.out_proj.")
+            key = key.replacingOccurrences(of: ".sa_layer_norm.", with: ".ln1.")
+            key = key.replacingOccurrences(of: ".ffn.lin1.", with: ".linear1.")
+            key = key.replacingOccurrences(of: ".ffn.lin2.", with: ".linear2.")
+            key = key.replacingOccurrences(of: ".output_layer_norm.", with: ".ln2.")
+            key = key.replacingOccurrences(of: "vocab_transform", with: "lm_head.dense")
+            key = key.replacingOccurrences(of: "vocab_layer_norm", with: "lm_head.ln")
+            key = key.replacingOccurrences(of: "vocab_projector", with: "lm_head.decoder")
+            key = key.replacingOccurrences(of: "distilbert.", with: "")
+            result[key] = item.value
+        }.filter { key, _ in key != "embeddings.position_ids" }
+    }
+}
+
+public struct BertConfiguration: Decodable, Sendable {
+    var layerNormEps: Float = 1e-12
+    var maxTrainedPositions: Int = 2048
+    var embedDim: Int = 768
+    var numHeads: Int = 12
+    var interDim: Int = 3072
+    var numLayers: Int = 12
+    var typeVocabularySize: Int = 2
+    var vocabularySize: Int = 30528
+    var maxPositionEmbeddings: Int = 0
+    var modelType: String
+
+    enum CodingKeys: String, CodingKey {
+        case layerNormEps = "layer_norm_eps"
+        case maxTrainedPositions = "max_trained_positions"
+        case vocabularySize = "vocab_size"
+        case maxPositionEmbeddings = "max_position_embeddings"
+        case modelType = "model_type"
+    }
+
+    enum BertCodingKeys: String, CodingKey {
+        case embedDim = "hidden_size"
+        case numHeads = "num_attention_heads"
+        case interDim = "intermediate_size"
+        case numLayers = "num_hidden_layers"
+        case typeVocabularySize = "type_vocab_size"
+    }
+
+    enum DistilBertCodingKeys: String, CodingKey {
+        case embedDim = "dim"
+        case numLayers = "n_layers"
+        case numHeads = "n_heads"
+        case interDim = "hidden_dim"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container: KeyedDecodingContainer<CodingKeys> =
+            try decoder.container(
+                keyedBy: CodingKeys.self)
+        layerNormEps =
+            try container.decodeIfPresent(
+                Float.self,
+                forKey: CodingKeys.layerNormEps.self)
+            ?? 1e-12
+        maxTrainedPositions =
+            try container.decodeIfPresent(
+                Int.self,
+                forKey: CodingKeys.maxTrainedPositions
+                    .self) ?? 2048
+        vocabularySize =
+            try container.decodeIfPresent(
+                Int.self,
+                forKey: CodingKeys.vocabularySize.self)
+            ?? 30528
+        maxPositionEmbeddings =
+            try container.decodeIfPresent(
+                Int.self,
+                forKey: CodingKeys.maxPositionEmbeddings
+                    .self) ?? 0
+        modelType = try container.decode(String.self, forKey: CodingKeys.modelType.self)
+
+        if modelType == "distilbert" {
+            let distilBertConfig: KeyedDecodingContainer<DistilBertCodingKeys> =
+                try decoder.container(
+                    keyedBy: DistilBertCodingKeys.self)
+            embedDim =
+                try distilBertConfig.decodeIfPresent(
+                    Int.self,
+                    forKey: DistilBertCodingKeys.embedDim.self) ?? 768
+            numHeads =
+                try distilBertConfig.decodeIfPresent(
+                    Int.self,
+                    forKey: DistilBertCodingKeys.numHeads.self) ?? 12
+            interDim =
+                try distilBertConfig.decodeIfPresent(
+                    Int.self, forKey: DistilBertCodingKeys.interDim.self)
+                ?? 3072
+            numLayers =
+                try distilBertConfig.decodeIfPresent(
+                    Int.self,
+                    forKey: DistilBertCodingKeys.numLayers.self) ?? 12
+            typeVocabularySize = 0
+        } else {
+            let bertConfig: KeyedDecodingContainer<BertCodingKeys> = try decoder.container(
+                keyedBy: BertCodingKeys.self)
+
+            embedDim =
+                try bertConfig.decodeIfPresent(
+                    Int.self,
+                    forKey: BertCodingKeys.embedDim.self) ?? 768
+            numHeads =
+                try bertConfig.decodeIfPresent(
+                    Int.self,
+                    forKey: BertCodingKeys.numHeads.self) ?? 12
+            interDim =
+                try bertConfig.decodeIfPresent(
+                    Int.self, forKey: BertCodingKeys.interDim.self)
+                ?? 3072
+            numLayers =
+                try bertConfig.decodeIfPresent(
+                    Int.self,
+                    forKey: BertCodingKeys.numLayers.self) ?? 12
+            typeVocabularySize =
+                try bertConfig.decodeIfPresent(
+                    Int.self,
+                    forKey: BertCodingKeys.typeVocabularySize
+                        .self) ?? 2
+        }
+    }
+}

--- a/Libraries/Embedders/Configuration.swift
+++ b/Libraries/Embedders/Configuration.swift
@@ -1,0 +1,138 @@
+// Copyright © 2024 Apple Inc.
+
+import Foundation
+
+public enum StringOrNumber: Codable, Equatable, Sendable {
+    case string(String)
+    case float(Float)
+
+    public init(from decoder: Decoder) throws {
+        let values = try decoder.singleValueContainer()
+
+        if let v = try? values.decode(Float.self) {
+            self = .float(v)
+        } else {
+            let v = try values.decode(String.self)
+            self = .string(v)
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .string(let v): try container.encode(v)
+        case .float(let v): try container.encode(v)
+        }
+    }
+}
+
+private class ModelTypeRegistry: @unchecked Sendable {
+
+    // Note: using NSLock as we have very small (just dictionary get/set)
+    // critical sections and expect no contention.  this allows the methods
+    // to remain synchronous.
+    private let lock = NSLock()
+
+    private var creators: [String: @Sendable (URL) throws -> EmbeddingModel] = [
+        "bert": {
+            url in
+            let configuration = try JSONDecoder().decode(
+                BertConfiguration.self, from: Data(contentsOf: url))
+            let model = BertModel(configuration)
+            return model
+        },
+        "roberta": {
+            url in
+            let configuration = try JSONDecoder().decode(
+                BertConfiguration.self, from: Data(contentsOf: url))
+            let model = BertModel(configuration)
+            return model
+        },
+        "xlm-roberta": {
+            url in
+            let configuration = try JSONDecoder().decode(
+                BertConfiguration.self, from: Data(contentsOf: url))
+            let model = BertModel(configuration)
+            return model
+        },
+        "distilbert": {
+            url in
+            let configuration = try JSONDecoder().decode(
+                BertConfiguration.self, from: Data(contentsOf: url))
+            let model = BertModel(configuration)
+            return model
+        },
+        "nomic_bert": {
+            url in
+            let configuration = try JSONDecoder().decode(
+                NomicBertConfiguration.self, from: Data(contentsOf: url))
+            let model = NomicBertModel(configuration)
+            return model
+        },
+    ]
+
+    public func registerModelType(
+        _ type: String, creator: @Sendable @escaping (URL) throws -> EmbeddingModel
+    ) {
+        lock.withLock {
+            creators[type] = creator
+        }
+    }
+
+    public func createModel(configuration: URL, rawValue: String) throws -> EmbeddingModel {
+        let creator = lock.withLock {
+            creators[rawValue]
+        }
+        guard let creator else {
+            throw EmbedderError(message: "Unsupported model type.")
+        }
+        return try creator(configuration)
+    }
+
+}
+
+private let modelTypeRegistry = ModelTypeRegistry()
+
+public struct ModelType: RawRepresentable, Codable, Sendable {
+    public let rawValue: String
+
+    public init(rawValue: String) {
+        self.rawValue = rawValue
+    }
+
+    public static func registerModelType(
+        _ type: String, creator: @Sendable @escaping (URL) throws -> EmbeddingModel
+    ) {
+        modelTypeRegistry.registerModelType(type, creator: creator)
+    }
+
+    public func createModel(configuration: URL) throws -> EmbeddingModel {
+        try modelTypeRegistry.createModel(configuration: configuration, rawValue: rawValue)
+    }
+}
+
+public struct BaseConfiguration: Codable, Sendable {
+    public let modelType: ModelType
+
+    public struct Quantization: Codable, Sendable {
+        public init(groupSize: Int, bits: Int) {
+            self.groupSize = groupSize
+            self.bits = bits
+        }
+
+        let groupSize: Int
+        let bits: Int
+
+        enum CodingKeys: String, CodingKey {
+            case groupSize = "group_size"
+            case bits = "bits"
+        }
+    }
+
+    public var quantization: Quantization?
+
+    enum CodingKeys: String, CodingKey {
+        case modelType = "model_type"
+        case quantization
+    }
+}

--- a/Libraries/Embedders/EmbeddingModel.swift
+++ b/Libraries/Embedders/EmbeddingModel.swift
@@ -1,0 +1,113 @@
+// Copyright © 2024 Apple Inc.
+
+import Foundation
+@preconcurrency import Hub
+import MLX
+import MLXNN
+import Tokenizers
+
+/// Container for models that guarantees single threaded access.
+///
+/// Wrap models used by e.g. the UI in a ModelContainer.  Callers can access
+/// the model and/or tokenizer:
+///
+/// ```swift
+/// let promptTokens = await modelContainer.perform { _, tokenizer in
+///     tokenizer.encode(text: prompt)
+/// }
+/// ```
+///
+/// or:
+///
+/// ```swift
+/// let result = await modelContainer.perform { model, tokenizer in
+///     LLM.generate(
+///         promptTokens: promptTokens, parameters: generateParameters, model: model,
+///         tokenizer: tokenizer, extraEOSTokens: modelConfiguration.extraEOSTokens
+///     ) { tokens in
+///     ...
+///     }
+/// }
+/// ```
+public actor ModelContainer {
+    let model: EmbeddingModel
+    let tokenizer: Tokenizer
+    let pooler: Pooling
+
+    public init(
+        model: EmbeddingModel, tokenizer: Tokenizer, pooler: Pooling = Pooling(strategy: .none)
+    ) {
+        self.model = model
+        self.tokenizer = tokenizer
+        self.pooler = pooler
+    }
+
+    /// build the model and tokenizer without passing non-sendable data over isolation barriers
+    public init(
+        hub: HubApi, modelDirectory: URL, configuration: ModelConfiguration
+    ) async throws {
+        self.model = try loadSynchronous(modelDirectory: modelDirectory)
+
+        let (tokenizerConfig, tokenizerData) = try await loadTokenizerConfig(
+            configuration: configuration, hub: hub)
+        self.tokenizer = try PreTrainedTokenizer(
+            tokenizerConfig: tokenizerConfig, tokenizerData: tokenizerData)
+        self.pooler = loadPooling(modelDirectory: modelDirectory)  //?? Pooling(strategy: .none)
+    }
+
+    /// Perform an action on the model and/or tokenizer.  Callers _must_ eval any `MLXArray` before returning as
+    /// `MLXArray` is not `Sendable`.
+    public func perform<R>(_ action: @Sendable (EmbeddingModel, Tokenizer, Pooling) throws -> R)
+        rethrows
+        -> R
+    {
+        try action(model, tokenizer, pooler)
+    }
+}
+
+extension Module {
+
+    /// Compute the number of parameters in a possibly quantized model
+    public func numParameters() -> Int {
+        return leafModules().flattenedValues().map {
+            mod -> Int in
+            if let qlin = mod as? QuantizedLinear {
+                return qlin.scales.size * qlin.groupSize
+            } else if let qemb = mod as? QuantizedEmbedding {
+                return qemb.scales.size * qemb.groupSize
+            } else {
+                return mod.parameters().flattenedValues().reduce(
+                    0,
+                    {
+                        $0 + $1.size
+                    })
+            }
+        }.reduce(0, +)
+    }
+}
+
+public struct EmbeddingModelOutput {
+    let hiddenStates: MLXArray?
+    let pooledOutput: MLXArray?
+}
+
+public protocol EmbeddingModel: Module {
+    var vocabularySize: Int { get }
+    func callAsFunction(
+        _ inputs: MLXArray, positionIds: MLXArray?, tokenTypeIds: MLXArray?,
+        attentionMask: MLXArray?
+    ) -> EmbeddingModelOutput
+    /// Optionally preprocess the weights and modify / remove values as needed.
+    func sanitize(weights: [String: MLXArray]) -> [String: MLXArray]
+}
+
+extension EmbeddingModel {
+    func callAsFunction(
+        _ inputs: MLXArray, positionIds: MLXArray? = nil, tokenTypeIds: MLXArray? = nil,
+        attentionMask: MLXArray? = nil
+    ) -> EmbeddingModelOutput {
+        return callAsFunction(
+            inputs, positionIds: positionIds, tokenTypeIds: tokenTypeIds,
+            attentionMask: attentionMask)
+    }
+}

--- a/Libraries/Embedders/Load.swift
+++ b/Libraries/Embedders/Load.swift
@@ -1,0 +1,110 @@
+// Copyright © 2024 Apple Inc.
+
+import Foundation
+@preconcurrency import Hub
+import MLX
+import MLXNN
+import MLXRandom
+import Tokenizers
+
+struct EmbedderError: Error {
+    let message: String
+}
+
+func prepareModelDirectory(
+    hub: HubApi, configuration: ModelConfiguration,
+    progressHandler: @Sendable @escaping (Progress) -> Void
+) async throws -> URL {
+    do {
+        switch configuration.id {
+        case .id(let id):
+            // download the model weights
+            let repo = Hub.Repo(id: id)
+            let modelFiles = ["*.safetensors", "config.json"]
+            return try await hub.snapshot(
+                from: repo, matching: modelFiles, progressHandler: progressHandler)
+
+        case .directory(let directory):
+            return directory
+        }
+    } catch Hub.HubClientError.authorizationRequired {
+        // an authorizationRequired means (typically) that the named repo doesn't exist on
+        // on the server so retry with local only configuration
+        return configuration.modelDirectory(hub: hub)
+    } catch {
+        let nserror = error as NSError
+        if nserror.domain == NSURLErrorDomain && nserror.code == NSURLErrorNotConnectedToInternet {
+            // Error Domain=NSURLErrorDomain Code=-1009 "The Internet connection appears to be offline."
+            // fall back to the local directory
+            return configuration.modelDirectory(hub: hub)
+        } else {
+            throw error
+        }
+    }
+}
+
+/// Load and return the model and tokenizer
+public func load(
+    hub: HubApi = HubApi(), configuration: ModelConfiguration,
+    progressHandler: @Sendable @escaping (Progress) -> Void = { _ in }
+) async throws -> (EmbeddingModel, Tokenizer) {
+    let modelDirectory = try await prepareModelDirectory(
+        hub: hub, configuration: configuration, progressHandler: progressHandler)
+    let model = try loadSynchronous(modelDirectory: modelDirectory)
+    let tokenizer = try await loadTokenizer(configuration: configuration, hub: hub)
+
+    return (model, tokenizer)
+}
+
+func loadSynchronous(modelDirectory: URL) throws -> EmbeddingModel {
+    // create the model (no weights loaded)
+    let configurationURL = modelDirectory.appending(component: "config.json")
+    let baseConfig = try JSONDecoder().decode(
+        BaseConfiguration.self, from: Data(contentsOf: configurationURL))
+
+    let model = try baseConfig.modelType.createModel(configuration: configurationURL)
+
+    // load the weights
+    var weights = [String: MLXArray]()
+    let enumerator = FileManager.default.enumerator(
+        at: modelDirectory, includingPropertiesForKeys: nil)!
+    for case let url as URL in enumerator {
+        if url.pathExtension == "safetensors" {
+            let w = try loadArrays(url: url)
+            for (key, value) in w {
+                weights[key] = value
+            }
+        }
+    }
+
+    // per-model cleanup
+    weights = model.sanitize(weights: weights)
+
+    // quantize if needed
+    if let quantization = baseConfig.quantization {
+        quantize(model: model, groupSize: quantization.groupSize, bits: quantization.bits) {
+            path, module in
+            weights["\(path).scales"] != nil
+        }
+    }
+
+    // apply the loaded weights
+    let parameters = ModuleParameters.unflattened(weights)
+    try model.update(parameters: parameters, verify: [.all])
+
+    eval(model)
+
+    return model
+}
+
+/// Load and return the model and tokenizer wrapped in a ``ModelContainer`` (provides
+/// thread safe access).
+public func loadModelContainer(
+    hub: HubApi = HubApi(), configuration: ModelConfiguration,
+    progressHandler: @Sendable @escaping (Progress) -> Void = { _ in }
+) async throws -> ModelContainer {
+    let modelDirectory = try await prepareModelDirectory(
+        hub: hub, configuration: configuration, progressHandler: progressHandler)
+    return try await ModelContainer(
+        hub: hub, modelDirectory: modelDirectory, configuration: configuration)
+}

--- a/Libraries/Embedders/Models.swift
+++ b/Libraries/Embedders/Models.swift
@@ -1,0 +1,145 @@
+// Copyright © 2024 Apple Inc.
+
+import Foundation
+import Hub
+
+/// Registry of models and any overrides that go with them, e.g. prompt augmentation.
+/// If asked for an unknown configuration this will use the model/tokenizer as-is.
+///
+/// The python tokenizers have a very rich set of implementations and configuration.  The
+/// swift-tokenizers code handles a good chunk of that and this is a place to augment that
+/// implementation, if needed.
+public struct ModelConfiguration: Sendable {
+
+    public enum Identifier: Sendable {
+        case id(String)
+        case directory(URL)
+    }
+
+    public var id: Identifier
+
+    public var name: String {
+        switch id {
+        case .id(let string):
+            string
+        case .directory(let url):
+            url.deletingLastPathComponent().lastPathComponent + "/" + url.lastPathComponent
+        }
+    }
+
+    /// pull the tokenizer from an alternate id
+    public let tokenizerId: String?
+
+    /// overrides for TokenizerModel/knownTokenizers -- useful before swift-transformers is updated
+    public let overrideTokenizer: String?
+
+    public init(
+        id: String, tokenizerId: String? = nil, overrideTokenizer: String? = nil
+    ) {
+        self.id = .id(id)
+        self.tokenizerId = tokenizerId
+        self.overrideTokenizer = overrideTokenizer
+    }
+
+    public init(
+        directory: URL, tokenizerId: String? = nil, overrideTokenizer: String? = nil
+    ) {
+        self.id = .directory(directory)
+        self.tokenizerId = tokenizerId
+        self.overrideTokenizer = overrideTokenizer
+    }
+
+    public func modelDirectory(hub: HubApi = HubApi()) -> URL {
+        switch id {
+        case .id(let id):
+            // download the model weights and config
+            let repo = Hub.Repo(id: id)
+            return hub.localRepoLocation(repo)
+
+        case .directory(let directory):
+            return directory
+        }
+    }
+
+    @MainActor
+    public static var registry = [String: ModelConfiguration]()
+
+    @MainActor
+    public static func register(configurations: [ModelConfiguration]) {
+        bootstrap()
+
+        for c in configurations {
+            registry[c.name] = c
+        }
+    }
+
+    @MainActor
+    public static func configuration(id: String) -> ModelConfiguration {
+        bootstrap()
+
+        if let c = registry[id] {
+            return c
+        } else {
+            return ModelConfiguration(id: id)
+        }
+    }
+}
+
+extension ModelConfiguration {
+    public static let bge_micro = ModelConfiguration(id: "TaylorAI/bge-micro-v2")
+    public static let gte_tiny = ModelConfiguration(id: "TaylorAI/gte-tiny")
+    public static let minilm_l6 = ModelConfiguration(id: "sentence-transformers/all-MiniLM-L6-v2")
+    public static let snowflake_xs = ModelConfiguration(id: "Snowflake/snowflake-arctic-embed-xs")
+    public static let minilm_l12 = ModelConfiguration(id: "sentence-transformers/all-MiniLM-L12-v2")
+    public static let bge_small = ModelConfiguration(id: "BAAI/bge-small-en-v1.5")
+    public static let multilingual_e5_small = ModelConfiguration(
+        id: "intfloat/multilingual-e5-small")
+    public static let bge_base = ModelConfiguration(id: "BAAI/bge-base-en-v1.5")
+    public static let nomic_text_v1 = ModelConfiguration(id: "nomic-ai/nomic-embed-text-v1")
+    public static let nomic_text_v1_5 = ModelConfiguration(id: "nomic-ai/nomic-embed-text-v1.5")
+    public static let bge_large = ModelConfiguration(id: "BAAI/bge-large-en-v1.5")
+    public static let snowflake_lg = ModelConfiguration(id: "Snowflake/snowflake-arctic-embed-l")
+    public static let bge_m3 = ModelConfiguration(id: "BAAI/bge-m3")
+    public static let mixedbread_large = ModelConfiguration(
+        id: "mixedbread-ai/mxbai-embed-large-v1")
+
+    private enum BootstrapState: Sendable {
+        case idle
+        case bootstrapping
+        case bootstrapped
+    }
+
+    @MainActor
+    static private var bootstrapState = BootstrapState.idle
+
+    @MainActor
+    static func bootstrap() {
+        switch bootstrapState {
+        case .idle:
+            bootstrapState = .bootstrapping
+            register(configurations: [
+                bge_micro,
+                gte_tiny,
+                minilm_l6,
+                snowflake_xs,
+                minilm_l12,
+                bge_small,
+                multilingual_e5_small,
+                bge_base,
+                nomic_text_v1,
+                nomic_text_v1_5,
+                bge_large,
+                snowflake_lg,
+                bge_m3,
+                mixedbread_large,
+            ])
+            bootstrapState = .bootstrapped
+
+        case .bootstrapping:
+            break
+
+        case .bootstrapped:
+            break
+        }
+    }
+}

--- a/Libraries/Embedders/NomicBert.swift
+++ b/Libraries/Embedders/NomicBert.swift
@@ -1,0 +1,522 @@
+// Copyright © 2024 Apple Inc.
+
+import Foundation
+import MLX
+import MLXFast
+import MLXNN
+
+class NomicEmbedding: Module {
+
+    let typeVocabularySize: Int
+    @ModuleInfo(key: "word_embeddings") var wordEmbeddings: Embedding
+    @ModuleInfo(key: "norm") var norm: LayerNorm
+    @ModuleInfo(key: "token_type_embeddings") var tokenTypeEmbeddings: Embedding?
+    @ModuleInfo(key: "position_embeddings") var positionEmbeddings: Embedding?
+
+    init(_ config: NomicBertConfiguration) {
+        typeVocabularySize = config.typeVocabularySize
+        _wordEmbeddings.wrappedValue = Embedding(
+            embeddingCount: config.vocabularySize, dimensions: config.embedDim)
+        _norm.wrappedValue = LayerNorm(
+            dimensions: config.embedDim, eps: config.layerNormEps)
+        if config.typeVocabularySize > 0 {
+            _tokenTypeEmbeddings.wrappedValue = Embedding(
+                embeddingCount: config.typeVocabularySize,
+                dimensions: config.embedDim)
+        }
+        if config.maxPositionEmbeddings > 0 {
+            _positionEmbeddings.wrappedValue = Embedding(
+                embeddingCount: config.maxPositionEmbeddings,
+                dimensions: config.embedDim)
+        }
+    }
+
+    func callAsFunction(
+        _ inputIds: MLXArray, positionIds: MLXArray? = nil,
+        tokenTypeIds: MLXArray? = nil
+    ) -> MLXArray {
+        let words = wordEmbeddings(inputIds)
+
+        if let tokenTypeIds, let tokenTypeEmbeddings {
+            words += tokenTypeEmbeddings(tokenTypeIds)
+        }
+        let positions =
+            positionIds ?? broadcast(MLXArray.arange(inputIds.dim(1)), to: inputIds.shape)
+        if let positionEmbeddings {
+            words += positionEmbeddings(positions)
+        }
+        return norm(words)
+    }
+}
+
+private class MLP: Module, UnaryLayer {
+    @ModuleInfo(key: "fc11") var up: Linear
+    @ModuleInfo(key: "fc12") var gate: Linear
+    @ModuleInfo(key: "fc2") var down: Linear
+
+    private static func scaledHiddenFeatures(config: NomicBertConfiguration)
+        -> Int
+    {
+        let multipleOf = 256
+        let hiddenFeatures: Int = config.MLPDim
+        return (hiddenFeatures + multipleOf - 1) / multipleOf * multipleOf
+    }
+
+    init(_ config: NomicBertConfiguration) {
+        let hiddenFeatures = MLP.scaledHiddenFeatures(config: config)
+        _up.wrappedValue = Linear(
+            config.embedDim, hiddenFeatures, bias: config.mlpFc1Bias)
+        _gate.wrappedValue = Linear(
+            config.embedDim, hiddenFeatures, bias: config.mlpFc1Bias)
+        _down.wrappedValue = Linear(
+            hiddenFeatures, config.embedDim, bias: config.mlpFc2Bias)
+    }
+
+    func callAsFunction(_ inputs: MLXArray) -> MLXArray {
+        let activations = up(inputs) * silu(gate(inputs))
+        return down(activations)
+    }
+}
+
+func computeBaseFrequency(
+    base: Float, dims: Int, ropeType: String,
+    ropeScaling: [String: StringOrNumber]?
+)
+    -> Float
+{
+    if ropeType != "llama3" {
+        return base
+    }
+
+    guard let ropeScaling = ropeScaling else {
+        return base
+    }
+
+    guard case .float(let factor) = ropeScaling["factor"],
+        case .float(let lowFreqFactor) = ropeScaling["low_freq_factor"]
+            ?? .float(1.0),
+        case .float(let highFreqFactor) = ropeScaling["high_freq_factor"]
+            ?? .float(4.0),
+        case .float(let oldContextLen) = ropeScaling[
+            "original_max_position_embeddings"]
+            ?? .float(8192)
+    else {
+        return base
+    }
+
+    let lowFreqWavelen = oldContextLen / lowFreqFactor
+    let highFreqWavelen = oldContextLen / highFreqFactor
+
+    let freqs = (0 ..< dims).compactMap { index -> Float? in
+        if index % 2 == 0 {
+            return pow(base, Float(index) / Float(dims))
+        }
+        return nil
+    }
+
+    let newBaseFreqs = freqs.map { freq -> Float in
+        let wavelen = 2 * .pi / freq
+        let smooth = max(
+            0,
+            min(
+                1,
+                (wavelen - highFreqWavelen) / (lowFreqWavelen - highFreqWavelen)
+            ))
+        return freq * ((1 - smooth) * factor + smooth)
+    }
+
+    return newBaseFreqs.reduce(0, +) / Float(newBaseFreqs.count)
+}
+
+private class DynamicNTKScalingRoPE: Module {
+    let dims: Int
+    let maxPositionEmbeddings: Int?
+    let traditional: Bool
+    let base: Float
+    var scale: Float
+    let ropeType: String
+    let ropeScaling: [String: StringOrNumber]?
+
+    init(
+        dims: Int, maxPositionEmbeddings: Int?, traditional: Bool = false,
+        base: Float = 10000, scale: Float = 1.0, ropeType: String = "default",
+        ropeScaling: [String: StringOrNumber]? = nil
+    ) {
+        self.dims = dims
+        self.maxPositionEmbeddings = maxPositionEmbeddings
+        self.traditional = traditional
+        self.base = computeBaseFrequency(
+            base: base, dims: dims, ropeType: ropeType, ropeScaling: ropeScaling
+        )
+        self.scale = scale
+        self.ropeType = ropeType
+        self.ropeScaling = ropeScaling
+    }
+
+    func callAsFunction(_ x: MLXArray, offset: Int = 0) -> MLXArray {
+        let seqLen = x.dim(1) + offset
+        var base = self.base
+        if let maxPositionEmbeddings, seqLen > maxPositionEmbeddings {
+            let factorAdjustment =
+                Float(seqLen) / Float(maxPositionEmbeddings) - 1
+            let dimensionRatio = Float(dims) / Float(Float(dims) - 2)
+            let adjustedScale =
+                scale * pow(1 + factorAdjustment, dimensionRatio)
+            base *= adjustedScale
+        }
+        return MLXFast.RoPE(
+            x, dimensions: dims, traditional: traditional, base: base,
+            scale: scale, offset: offset)
+    }
+}
+
+private class Attention: Module {
+    let numHeads: Int
+    let headDim: Int
+
+    @ModuleInfo(key: "Wqkv") var wqkv: Linear
+    @ModuleInfo(key: "out_proj") var wo: Linear
+
+    enum PositionalEncoding {
+        case rope(RoPE)
+        case dynamicNTKScalingRoPE(DynamicNTKScalingRoPE)
+
+        func applyEncoding(_ x: MLXArray, offset: Int = 0) -> MLXArray {
+            switch self {
+            case .rope(let rope):
+                return rope.callAsFunction(x, offset: offset)
+            case .dynamicNTKScalingRoPE(let dynamicNTKScalingRoPE):
+                return dynamicNTKScalingRoPE.callAsFunction(x, offset: offset)
+            }
+        }
+    }
+
+    let rope: PositionalEncoding
+    let rotaryEmbDim: Int
+    let normFactor: Float
+
+    init(_ config: NomicBertConfiguration) {
+        _wqkv.wrappedValue = Linear(
+            config.embedDim, 3 * config.embedDim, bias: config.qkvProjBias)
+        _wo.wrappedValue = Linear(
+            config.embedDim, config.embedDim, bias: config.qkvProjBias)
+        numHeads = config.numHeads
+        headDim = config.embedDim / numHeads
+        rotaryEmbDim = Int(Float(headDim) * config.rotaryEmbFraction)
+        normFactor = sqrt(Float(headDim))
+
+        if config.rotaryScalingFactor != nil {
+            rope = .dynamicNTKScalingRoPE(
+                DynamicNTKScalingRoPE(
+                    dims: rotaryEmbDim,
+                    maxPositionEmbeddings: config.maxPositionEmbeddings,
+                    traditional: config.rotaryEmbInterleaved,
+                    base: config.rotaryEmbBase,
+                    scale: config.rotaryScalingFactor!))
+        } else {
+            rope = .rope(
+                RoPE(
+                    dimensions: rotaryEmbDim,
+                    traditional: config.rotaryEmbInterleaved,
+                    base: config.rotaryEmbBase,
+                    scale: 1.0)
+            )
+        }
+    }
+
+    func callAsFunction(_ inputs: MLXArray, mask: MLXArray? = nil) -> MLXArray {
+        let (B, L) = (inputs.dim(0), inputs.dim(1))
+        let queryPos = numHeads * headDim
+        let qkv = split(
+            wqkv(inputs), indices: [queryPos, queryPos * 2], axis: -1
+        )
+        var queries = qkv[0]
+        var keys = qkv[1]
+        var values = qkv[2]
+
+        // prepare the queries, keys and values for the attention computation
+        queries = queries.reshaped(B, L, numHeads, -1).transposed(
+            0, 2, 1, 3)
+        keys = keys.reshaped(B, L, numHeads, -1).transposed(0, 2, 1, 3)
+        values = values.reshaped(B, L, numHeads, -1).transposed(0, 2, 1, 3)
+
+        if rotaryEmbDim > 0 {
+            queries = rope.applyEncoding(queries)
+            keys = rope.applyEncoding(keys)
+        }
+        var scores = queries.matmul(keys.transposed(0, 1, 3, 2)) / normFactor
+
+        if let mask {
+            scores = scores + mask
+        }
+        let probs = softmax(scores, axis: -1)
+
+        let output = matmul(probs, values).transposed(0, 2, 1, 3).reshaped(B, L, -1)
+        return wo(output)
+    }
+}
+
+private class TransformerBlock: Module {
+    @ModuleInfo(key: "attn") var attention: Attention
+    @ModuleInfo(key: "norm1") var postAttentionLayerNorm: LayerNorm
+    @ModuleInfo(key: "norm2") var outputLayerNorm: LayerNorm
+    @ModuleInfo(key: "mlp") var mlp: MLP
+
+    init(_ config: NomicBertConfiguration) {
+        _attention.wrappedValue = Attention(config)
+        _mlp.wrappedValue = MLP(config)
+        _outputLayerNorm.wrappedValue = LayerNorm(
+            dimensions: config.embedDim, eps: config.layerNormEps)
+        _postAttentionLayerNorm.wrappedValue = LayerNorm(
+            dimensions: config.embedDim, eps: config.layerNormEps)
+    }
+
+    func callAsFunction(_ inputs: MLXArray, mask: MLXArray? = nil) -> MLXArray {
+        let attentionOut = attention(inputs, mask: mask)
+        let addAndNorm = postAttentionLayerNorm(attentionOut + inputs)
+        let mlpOut = mlp(addAndNorm)
+        return outputLayerNorm(addAndNorm + mlpOut)
+    }
+}
+
+private class LMHead: Module {
+    @ModuleInfo(key: "dense") var dense: Linear
+    @ModuleInfo(key: "ln") var layerNorm: LayerNorm
+    @ModuleInfo(key: "decoder") var decoder: Linear
+
+    init(_ config: NomicBertConfiguration) {
+        _dense.wrappedValue = Linear(
+            config.embedDim, config.embedDim, bias: config.mlpFc1Bias)
+        _layerNorm.wrappedValue = LayerNorm(
+            dimensions: config.embedDim, eps: config.layerNormEps)
+        _decoder.wrappedValue = Linear(
+            config.embedDim, config.vocabularySize, bias: config.mlpFc1Bias)
+    }
+    func callAsFunction(_ inputs: MLXArray) -> MLXArray {
+        return decoder(layerNorm(silu(dense(inputs))))
+    }
+}
+
+private class Encoder: Module {
+
+    let layers: [TransformerBlock]
+
+    init(
+        _ config: NomicBertConfiguration
+    ) {
+        precondition(config.vocabularySize > 0)
+
+        layers = (0 ..< config.numLayers).map {
+            _ in TransformerBlock(config)
+        }
+    }
+
+    func callAsFunction(_ inputs: MLXArray, attentionMask: MLXArray? = nil) -> MLXArray {
+        var outputs = inputs
+        for (index, layer) in layers.enumerated() {
+            outputs = layer(outputs, mask: attentionMask)
+        }
+        return outputs
+    }
+}
+
+public class NomicBertModel: Module, EmbeddingModel {
+    @ModuleInfo(key: "lm_head") fileprivate var lmHead: LMHead?
+    @ModuleInfo(key: "embeddings") var embedder: NomicEmbedding
+    let pooler: Linear?
+    fileprivate let encoder: Encoder
+    public var vocabularySize: Int
+
+    public init(
+        _ config: NomicBertConfiguration, pooler: Bool = true,
+        lmHead: Bool = false
+    ) {
+        precondition(config.vocabularySize > 0)
+        vocabularySize = config.vocabularySize
+        encoder = Encoder(config)
+        _embedder.wrappedValue = NomicEmbedding(config)
+
+        if pooler {
+            self.pooler = Linear(config.embedDim, config.embedDim)
+        } else {
+            self.pooler = nil
+        }
+        if lmHead {
+            _lmHead.wrappedValue = LMHead(config)
+        }
+    }
+
+    public func callAsFunction(
+        _ inputs: MLXArray, positionIds: MLXArray? = nil, tokenTypeIds: MLXArray? = nil,
+        attentionMask: MLXArray? = nil
+    )
+        -> EmbeddingModelOutput
+    {
+        var inp = inputs
+        if inp.ndim == 1 {
+            inp = inp.reshaped(1, -1)
+        }
+        var mask = attentionMask
+        if mask != nil {
+            mask = mask!.asType(embedder.wordEmbeddings.weight.dtype).expandedDimensions(axes: [
+                1, 2,
+            ]).log()
+        }
+        let outputs = encoder(
+            embedder(
+                inp, positionIds: positionIds, tokenTypeIds: tokenTypeIds),
+            attentionMask: mask)
+        if let lmHead {
+            return EmbeddingModelOutput(hiddenStates: lmHead(outputs), pooledOutput: nil)
+        }
+        if let pooler {
+            return EmbeddingModelOutput(
+                hiddenStates: outputs, pooledOutput: tanh(pooler(outputs[0..., 0])))
+        }
+        return EmbeddingModelOutput(hiddenStates: outputs, pooledOutput: nil)
+    }
+
+    public func sanitize(weights: [String: MLXArray]) -> [String: MLXArray] {
+        weights.reduce(into: [:]) { result, item in
+            var key = item.key.replacingOccurrences(
+                of: "emb_ln", with: "embeddings.norm")
+            key = key.replacingOccurrences(of: "bert.", with: "")
+            key = key.replacingOccurrences(
+                of: "cls.predictions.transform.dense.", with: "lm_head.dense.")
+            key = key.replacingOccurrences(
+                of: "cls.predictions.transform.LayerNorm.", with: "lm_head.ln.")
+            key = key.replacingOccurrences(
+                of: "cls.predictions.decoder", with: "lm_head.decoder")
+            key = key.replacingOccurrences(of: "pooler.dense.", with: "pooler.")
+            result[key] = item.value
+        }
+    }
+}
+
+public struct NomicBertConfiguration: Decodable, Sendable {
+    var layerNormEps: Float = 1e-12
+    var maxTrainedPositions: Int = 2048
+    var mlpFc1Bias: Bool = false
+    var mlpFc2Bias: Bool = false
+    var embedDim: Int = 768
+    var numHeads: Int = 12
+    var MLPDim: Int = 3072
+    var numLayers: Int = 12
+    var qkvProjBias: Bool = false
+    var rotaryEmbBase: Float = 1000
+    var rotaryEmbFraction: Float = 1.0
+    var rotaryEmbInterleaved: Bool = false
+    var rotaryEmbScaleBase: Float?
+    var rotaryScalingFactor: Float?
+    var typeVocabularySize: Int = 2
+    var vocabularySize: Int = 30528
+    var maxPositionEmbeddings: Int = 0
+
+    enum CodingKeys: String, CodingKey {
+        case layerNormEps = "layer_norm_epsilon"
+        case maxTrainedPositions = "max_trained_positions"
+        case mlpFc1Bias = "mlp_fc1_bias"
+        case mlpFc2Bias = "mlp_fc2_bias"
+        case embedDim = "n_embd"
+        case numHeads = "n_head"
+        case MLPDim = "n_inner"
+        case numLayers = "n_layer"
+        case qkvProjBias = "qkv_proj_bias"
+        case rotaryEmbBase = "rotary_emb_base"
+        case rotaryEmbFraction = "rotary_emb_fraction"
+        case rotaryEmbInterleaved = "rotary_emb_interleaved"
+        case rotaryEmbScaleBase = "rotary_emb_scale_base"
+        case rotaryScalingFactor = "rotary_scaling_factor"
+        case typeVocabularySize = "type_vocab_size"
+        case useCache = "use_cache"
+        case vocabularySize = "vocab_size"
+        case maxPositionEmbeddings = "max_position_embeddings"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container: KeyedDecodingContainer<NomicBertConfiguration.CodingKeys> =
+            try decoder.container(
+                keyedBy: NomicBertConfiguration.CodingKeys.self)
+        layerNormEps =
+            try container.decodeIfPresent(
+                Float.self,
+                forKey: NomicBertConfiguration.CodingKeys.layerNormEps.self)
+            ?? 1e-12
+        maxTrainedPositions =
+            try container.decodeIfPresent(
+                Int.self,
+                forKey: NomicBertConfiguration.CodingKeys.maxTrainedPositions
+                    .self) ?? 2048
+        mlpFc1Bias =
+            try container.decodeIfPresent(
+                Bool.self,
+                forKey: NomicBertConfiguration.CodingKeys.mlpFc1Bias.self)
+            ?? false
+        mlpFc2Bias =
+            try container.decodeIfPresent(
+                Bool.self,
+                forKey: NomicBertConfiguration.CodingKeys.mlpFc2Bias.self)
+            ?? false
+        embedDim =
+            try container.decodeIfPresent(
+                Int.self,
+                forKey: NomicBertConfiguration.CodingKeys.embedDim.self) ?? 768
+        numHeads =
+            try container.decodeIfPresent(
+                Int.self,
+                forKey: NomicBertConfiguration.CodingKeys.numHeads.self) ?? 12
+        MLPDim =
+            try container.decodeIfPresent(
+                Int.self, forKey: NomicBertConfiguration.CodingKeys.MLPDim.self)
+            ?? 3072
+        numLayers =
+            try container.decodeIfPresent(
+                Int.self,
+                forKey: NomicBertConfiguration.CodingKeys.numLayers.self) ?? 12
+        qkvProjBias =
+            try container.decodeIfPresent(
+                Bool.self,
+                forKey: NomicBertConfiguration.CodingKeys.qkvProjBias.self)
+            ?? false
+        rotaryEmbBase =
+            try container.decodeIfPresent(
+                Float.self,
+                forKey: NomicBertConfiguration.CodingKeys.rotaryEmbBase.self)
+            ?? 1000
+        rotaryEmbFraction =
+            try container.decodeIfPresent(
+                Float.self,
+                forKey: NomicBertConfiguration.CodingKeys.rotaryEmbFraction.self
+            ) ?? 1.0
+        rotaryEmbInterleaved =
+            try container.decodeIfPresent(
+                Bool.self,
+                forKey: NomicBertConfiguration.CodingKeys.rotaryEmbInterleaved
+                    .self) ?? false
+        rotaryEmbScaleBase =
+            try container.decodeIfPresent(
+                Float.self,
+                forKey: NomicBertConfiguration.CodingKeys.rotaryEmbScaleBase)
+            ?? nil
+        rotaryScalingFactor =
+            try container.decodeIfPresent(
+                Float.self,
+                forKey: NomicBertConfiguration.CodingKeys.rotaryScalingFactor)
+            ?? nil
+        typeVocabularySize =
+            try container.decodeIfPresent(
+                Int.self,
+                forKey: NomicBertConfiguration.CodingKeys.typeVocabularySize
+                    .self) ?? 2
+        vocabularySize =
+            try container.decodeIfPresent(
+                Int.self,
+                forKey: NomicBertConfiguration.CodingKeys.vocabularySize.self)
+            ?? 30528
+        maxPositionEmbeddings =
+            try container.decodeIfPresent(
+                Int.self,
+                forKey: NomicBertConfiguration.CodingKeys.maxPositionEmbeddings
+                    .self) ?? 0
+    }
+}

--- a/Libraries/Embedders/Pooling.swift
+++ b/Libraries/Embedders/Pooling.swift
@@ -1,0 +1,111 @@
+// Copyright © 2024 Apple Inc.
+
+import Foundation
+import MLX
+import MLXFast
+import MLXLinalg
+import MLXNN
+
+public struct PoolingConfiguration: Codable {
+    public let dimension: Int
+    public let poolingModeClsToken: Bool
+    public let poolingModeMeanTokens: Bool
+    public let poolingModeMaxTokens: Bool
+    public let poolingModeLastToken: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case dimension = "word_embedding_dimension"
+        case poolingModeClsToken = "pooling_mode_cls_token"
+        case poolingModeMeanTokens = "pooling_mode_mean_tokens"
+        case poolingModeMaxTokens = "pooling_mode_max_tokens"
+        case poolingModeLastToken = "pooling_mode_lasttoken"
+    }
+}
+
+func loadPooling(modelDirectory: URL) -> Pooling {
+    let configurationURL = modelDirectory.appending(components: "1_Pooling", "config.json")
+    guard let poolingConfig = try? JSONDecoder().decode(
+            PoolingConfiguration.self, from: Data(contentsOf: configurationURL))
+    else {
+        return Pooling(strategy: .none)
+    }
+
+    return Pooling(config: poolingConfig)
+}
+
+public class Pooling: Module {
+    public enum Strategy {
+        case mean
+        case cls
+        case first
+        case last
+        case max
+        case none
+    }
+    let strategy: Strategy
+    let dimension: Int?
+
+    public init(
+        strategy: Strategy, dimension: Int? = nil
+    ) {
+        self.strategy = strategy
+        self.dimension = dimension
+    }
+
+    public init(
+        config: PoolingConfiguration
+    ) {
+        dimension = config.dimension
+        if config.poolingModeClsToken {
+            strategy = .cls
+        } else if config.poolingModeMeanTokens {
+            strategy = .mean
+        } else if config.poolingModeMaxTokens {
+            strategy = .max
+        } else if config.poolingModeLastToken {
+            strategy = .last
+        } else {
+            strategy = .first
+        }
+    }
+
+    public func callAsFunction(
+        _ inputs: EmbeddingModelOutput, mask: MLXArray? = nil, normalize: Bool = false,
+        applyLayerNorm: Bool = false
+    ) -> MLXArray {
+        let _mask = mask ?? MLXArray.ones(Array(inputs.hiddenStates?.shape[0 ..< 2] ?? [0]))
+
+        var pooled: MLXArray
+        switch self.strategy {
+        case .mean:
+            pooled =
+                sum(
+                    inputs.hiddenStates! * _mask.expandedDimensions(axes: [-1]),
+                    axis: 1)
+                / sum(_mask, axis: -1, keepDims: true)
+        case .max:
+            pooled = MLX.max(
+                inputs.hiddenStates! * _mask.expandedDimensions(axes: [-1]), axis: 1)
+        case .first:
+            pooled = inputs.hiddenStates![0..., 0, 0...]
+        case .last:
+            pooled = inputs.hiddenStates![0..., -1, 0...]
+        case .cls:
+            pooled =
+                inputs.pooledOutput
+                ?? inputs.hiddenStates![0..., 0, 0...]
+        case .none:
+            pooled = inputs.pooledOutput ?? inputs.hiddenStates!
+        }
+        if applyLayerNorm {
+            pooled = MLXFast.layerNorm(pooled, eps: 1e-5)
+        }
+        if let dimension {
+            pooled = pooled[0..., 0 ..< dimension]
+        }
+        if normalize {
+            pooled = pooled / norm(pooled, axis: -1, keepDims: true)
+        }
+        return pooled
+    }
+}

--- a/Libraries/Embedders/Pooling.swift
+++ b/Libraries/Embedders/Pooling.swift
@@ -24,7 +24,8 @@ public struct PoolingConfiguration: Codable {
 
 func loadPooling(modelDirectory: URL) -> Pooling {
     let configurationURL = modelDirectory.appending(components: "1_Pooling", "config.json")
-    guard let poolingConfig = try? JSONDecoder().decode(
+    guard
+        let poolingConfig = try? JSONDecoder().decode(
             PoolingConfiguration.self, from: Data(contentsOf: configurationURL))
     else {
         return Pooling(strategy: .none)

--- a/Libraries/Embedders/README.md
+++ b/Libraries/Embedders/README.md
@@ -11,7 +11,7 @@ let modelContainer = try await MLXEmbedders.loadModelContainer(
 let result = await modelContainer.perform {
     (model: EmbeddingModel, tokenizer, pooling) -> [[Float]] in
     let inputs = [
-        "search_query: Animals in Tropica Climates.",
+        "search_query: Animals in Tropical Climates.",
         "search_document: Elephants",
         "search_document: Horses",
         "search_document: Polar Bears",

--- a/Libraries/Embedders/README.md
+++ b/Libraries/Embedders/README.md
@@ -1,0 +1,45 @@
+#  MLXEmbedders
+
+This directory contains ports of popular Encoders / Embedding Models. 
+
+## Usage Example
+
+```swift
+
+let modelContainer = try await MLXEmbedders.loadModelContainer(
+    configuration: ModelConfiguration.nomic_text_v1_5)
+let result = await modelContainer.perform {
+    (model: EmbeddingModel, tokenizer, pooling) -> [[Float]] in
+    let inputs = [
+        "search_query: Animals in Tropica Climates.",
+        "search_document: Elephants",
+        "search_document: Horses",
+        "search_document: Polar Bears",
+    ].map {
+        tokenizer.encode(text: $0, addSpecialTokens: true)
+    }
+    // Pad to longest
+    let maxLength = inputs.reduce(into: 16) { acc, elem in
+        acc = max(acc, elem.count)
+    }
+
+    let padded = stacked(
+        inputs.map { elem in
+            MLXArray(
+                elem
+                    + Array(
+                        repeating: tokenizer.eosTokenId ?? 0,
+                        count: maxLength - elem.count))
+        })
+    let mask = (padded .!= tokenizer.eosTokenId ?? 0)
+    let tokenTypes = MLXArray.zeros(like: padded)
+    let result = pooling(
+        model(padded, positionIds: nil, tokenTypeIds: tokenTypes, attentionMask: mask),
+        normalize: true, applyLayerNorm: true
+    ).eval()
+    return result.map { $0.asArray(Float.self) }
+}
+```
+
+
+Ported to swift from [taylorai/mlx_embedding_models](https://github.com/taylorai/mlx_embedding_models/tree/main)

--- a/Libraries/Embedders/Tokenizer.swift
+++ b/Libraries/Embedders/Tokenizer.swift
@@ -1,0 +1,58 @@
+//
+//  Tokenizer.swift
+//
+//
+//  Created by Anish Basu on 10/18/24.
+//
+// Copyright © 2024 Apple Inc.
+
+import Foundation
+import Hub
+import Tokenizers
+
+public func loadTokenizer(configuration: ModelConfiguration, hub: HubApi) async throws -> Tokenizer
+{
+    let (tokenizerConfig, tokenizerData) = try await loadTokenizerConfig(
+        configuration: configuration, hub: hub)
+
+    return try PreTrainedTokenizer(
+        tokenizerConfig: tokenizerConfig, tokenizerData: tokenizerData)
+}
+
+func loadTokenizerConfig(configuration: ModelConfiguration, hub: HubApi) async throws -> (
+    Config, Config
+) {
+    // from AutoTokenizer.from() -- this lets us override parts of the configuration
+    let config: LanguageModelConfigurationFromHub
+
+    switch configuration.id {
+    case .id(let id):
+        do {
+            // the load can fail (async when we try to use it)
+            let loaded = LanguageModelConfigurationFromHub(
+                modelName: configuration.tokenizerId ?? id, hubApi: hub)
+            _ = try await loaded.tokenizerConfig
+            config = loaded
+        } catch {
+            let nserror = error as NSError
+            if nserror.domain == NSURLErrorDomain
+                && nserror.code == NSURLErrorNotConnectedToInternet
+            {
+                // Internet connection appears to be offline -- fall back to loading from
+                // the local directory
+                config = LanguageModelConfigurationFromHub(
+                    modelFolder: configuration.modelDirectory(hub: hub), hubApi: hub)
+            } else {
+                throw error
+            }
+        }
+    case .directory(let directory):
+        config = LanguageModelConfigurationFromHub(modelFolder: directory, hubApi: hub)
+    }
+
+    guard let tokenizerConfig = try await config.tokenizerConfig else {
+        throw EmbedderError(message: "missing config")
+    }
+    let tokenizerData = try await config.tokenizerData
+    return (tokenizerConfig, tokenizerData)
+}

--- a/Libraries/Embedders/Tokenizer.swift
+++ b/Libraries/Embedders/Tokenizer.swift
@@ -1,9 +1,3 @@
-//
-//  Tokenizer.swift
-//
-//
-//  Created by Anish Basu on 10/18/24.
-//
 // Copyright © 2024 Apple Inc.
 
 import Foundation

--- a/Package.resolved
+++ b/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/maiqingqiang/Jinja",
       "state" : {
-        "revision" : "5b0703d19a8901b76948753e5c5e3ca77043d33f",
-        "version" : "1.0.0"
+        "revision" : "6dbe4c449469fb586d0f7339f900f0dd4d78b167",
+        "version" : "1.0.6"
       }
     },
     {
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ml-explore/mlx-swift",
       "state" : {
-        "revision" : "86ad75ab1ee96cd70325732b37cd830f87d7e43f",
-        "version" : "0.16.1"
+        "revision" : "d649c62b77c487c25012910b0d02b30283d388ca",
+        "version" : "0.18.1"
       }
     },
     {
@@ -68,8 +68,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/huggingface/swift-transformers",
       "state" : {
-        "revision" : "104e8ceb1bb714c4aa1619fa20bdfeb537433492",
-        "version" : "0.1.11"
+        "revision" : "d42fdae473c49ea216671da8caae58e102d28709",
+        "version" : "0.1.14"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -41,6 +41,20 @@ let package = Package(
             ]
         ),
         .target(
+            name: "MLXEmbedders",
+            dependencies: [
+                .product(name: "MLX", package: "mlx-swift"),
+                .product(name: "MLXFast", package: "mlx-swift"),
+                .product(name: "MLXNN", package: "mlx-swift"),
+                .product(name: "Transformers", package: "swift-transformers"),
+                .product(name: "MLXLinalg", package: "mlx-swift"),
+            ],
+            path: "Libraries/Embedders",
+            exclude: [
+                "README.md"
+            ]
+        ),
+        .target(
             name: "MLXMNIST",
             dependencies: [
                 .product(name: "MLX", package: "mlx-swift"),


### PR DESCRIPTION
This PR adds support for Encoder models, specifically:

- BERT
- DistilBERT
- RoBERTa
- XLMRoBERTa
- NomicBERT

It has been ported over from python from [taylorai/mlx_embedding_models](https://github.com/taylorai/mlx_embedding_models/tree/main).