### PR TITLE
Update `asData` for StableDiffusion Image

### DIFF
--- a/Libraries/StableDiffusion/Image.swift
+++ b/Libraries/StableDiffusion/Image.swift
@@ -92,7 +92,7 @@ public struct Image {
             }
         }
 
-        let holder = DataHolder(raster.asData())
+        let holder = DataHolder(raster.asData(access: .copy).data)
 
         let payload = Unmanaged.passRetained(holder).toOpaque()
         func release(payload: UnsafeMutableRawPointer?, data: UnsafeMutableRawPointer?) {


### PR DESCRIPTION
Use the new `.asData(access: .copy).data` to replace `.asData()`