### PR TITLE
Expose MLXEmbedders as a library product

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,6 +20,9 @@ let package = Package(
             name: "MLXMNIST",
             targets: ["MLXMNIST"]),
         .library(
+            name: "MLXEmbedders",
+            targets: ["MLXEmbedders"]),
+        .library(
             name: "StableDiffusion",
             targets: ["StableDiffusion"]),
     ],

--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ See also:
 
 - [MLX troubleshooting](https://ml-explore.github.io/mlx-swift/MLX/documentation/mlx/troubleshooting)
 
-## Installation of MLXLLM and MLXMNIST libraries
+## Installation of libraries
 
-The MLXLLM, MLXMNIST and StableDiffusion libraries in the example repo are available
+The MLXLLM, MLXVLM, MLXLMCommon, MLXMNIST, MLXEmbedders, and StableDiffusion libraries in the example repo are available
 as Swift Packages.
 
 


### PR DESCRIPTION
* [`Package.swift`](diffhunk://#diff-f913940c58e8744a2af1c68b909bb6383e49007e6c5a12fb03104a9006ae677eR22-R24): Added a new library `MLXEmbedders` to the package targets.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L42-R44): Updated the installation section to include the `MLXEmbedders` library along with other existing libraries.