### PR TITLE
turn on docs build

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,0 +1,4 @@
+version: 1
+builder:
+  configs:
+    - documentation_targets: [MLXLLM, MLXVLM, MLXLMCommon, MLXMNIST, MLXEmbedders, StableDiffusion]

--- a/Package.swift
+++ b/Package.swift
@@ -139,3 +139,12 @@ let package = Package(
         ),
     ]
 )
+
+if Context.environment["MLX_SWIFT_BUILD_DOC"] == "1"
+    || Context.environment["SPI_GENERATE_DOCS"] == "1"
+{
+    // docc builder
+    package.dependencies.append(
+        .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.3.0")
+    )
+}


### PR DESCRIPTION
This should turn on the docs build in the swift package index (like we have for mlx-swift).  Once that is going I will follow up with a PR to link to the result (plus any docs fixes required).