### PR TITLE
Fix SD generation in batch mode

### DIFF
--- a/Libraries/StableDiffusion/StableDiffusion.swift
+++ b/Libraries/StableDiffusion/StableDiffusion.swift
@@ -255,7 +255,7 @@ open class StableDiffusion {
         xt: MLXArray, t: MLXArray, tPrev: MLXArray, conditioning: MLXArray, cfgWeight: Float,
         textTime: (MLXArray, MLXArray)?
     ) -> MLXArray {
-        let xtUnet = cfgWeight > 1 ? concatenated([xt, xt], axis: 0) : xt 
+        let xtUnet = cfgWeight > 1 ? concatenated([xt, xt], axis: 0) : xt
         let tUnet = broadcast(t, to: [xtUnet.count])
 
         var epsPred = unet(xtUnet, timestep: tUnet, encoderX: conditioning, textTime: textTime)

--- a/Libraries/StableDiffusion/StableDiffusion.swift
+++ b/Libraries/StableDiffusion/StableDiffusion.swift
@@ -255,7 +255,7 @@ open class StableDiffusion {
         xt: MLXArray, t: MLXArray, tPrev: MLXArray, conditioning: MLXArray, cfgWeight: Float,
         textTime: (MLXArray, MLXArray)?
     ) -> MLXArray {
-        let xtUnet = cfgWeight > 1 ? repeated(xt, count: 2, axis: 0) : xt
+        let xtUnet = cfgWeight > 1 ? concatenated([xt, xt], axis: 0) : xt 
         let tUnet = broadcast(t, to: [xtUnet.count])
 
         var epsPred = unet(xtUnet, timestep: tUnet, encoderX: conditioning, textTime: textTime)


### PR DESCRIPTION
This PR fixes a bug where generating images in batch mode would fail with the SD2.1 preset.

This is due to the way the positive and negative prompts are laid out. If you request, say, 4 images, in SD2.1 pipeline with negative prompt, the text embeddings will be arranged like so along the batch dim : 
```
[p,n] -> [p, p, p, p, n, n, n, n]
```
where `p` are positive prompt embeddings and `n` negative.

This is the result of this line
```swift
// repeat the conditioning for each of the generated images
if imageCount > 1 {
    conditioning = repeated(conditioning, count: imageCount, axis: 0)
}
```

However when initializing the random latents for the diffusion process, first, as many latents as images requested are sampled

```swift
 let xt = sampler.samplePrior(
    shape: [parameters.imageCount] + parameters.latentSize + [autoencoder.latentChannels],
    dType: dType)
```

And then they are duplicated to allow for the positive and negative prompts when CFG is enabled
```swift
 let xtUnet = cfgWeight > 1 ? repeated(xt, count: 2, axis: 0) : xt
```

However this will layout the `x` variables along the batch dim thusly:
```
[x1, x2, x3, x4] -> [x1, x1, x2, x2, x3, x3, x4, x4]
```

I believe the correct order is  this

```
[x1, x2, x3, x4] -> [x1, x2, x3, x4, x1, x2, x3, x4]
```

i.e. all positives, then all negatives, as to match with the text embeddings. Therefore the correct operation is not `repeated` but `concat`, as proposed in this PR.

The python code in mlx-examples [agrees with me](https://github.com/ml-explore/mlx-examples/blob/d4ef909d4ab44d9f8cf89f5baa8a433d76d7d6b1/stable_diffusion/stable_diffusion/__init__.py#L70)

```python
x_t_unet = mx.concatenate([x_t] * 2, axis=0) if cfg_weight > 1 else x_t
```
