### PR TITLE
fix llm-tool example resize bug

### DIFF
--- a/Tools/llm-tool/LLMTool.swift
+++ b/Tools/llm-tool/LLMTool.swift
@@ -225,7 +225,7 @@ struct EvaluateCommand: AsyncParsableCommand {
                 size = CGSize(width: v, height: v)
             } else {
                 let v0 = resize[0]
-                let v1 = resize[0]
+                let v1 = resize[1]
                 size = CGSize(width: v0, height: v1)
             }
             input.processing.resize = size


### PR DESCRIPTION
it is trivial but obvious bug I found while looking over example codes

with resize parameter like this

<img width="535" alt="Screenshot 2024-12-24 at 11 27 05 PM" src="https://github.com/user-attachments/assets/6092a4a4-6cb4-4c84-9cc5-32894a9c3ba4" />

AS-IS
<img width="222" alt="Screenshot 2024-12-24 at 11 27 44 PM" src="https://github.com/user-attachments/assets/8c85aae4-ec5c-4078-a4b6-d0b00d433d7b" />


TO-BE
<img width="198" alt="Screenshot 2024-12-24 at 11 28 14 PM" src="https://github.com/user-attachments/assets/1478ae4e-af60-43b3-b7da-93c076d6e4af" />
