### PR TITLE
llm-tool: fix prompt from file

### DIFF
--- a/Tools/llm-tool/LLMTool.swift
+++ b/Tools/llm-tool/LLMTool.swift
@@ -212,7 +212,7 @@ struct EvaluateCommand: AsyncParsableCommand {
 
     private func userInput(modelConfiguration: ModelConfiguration) -> UserInput {
         // prompt and images
-        let prompt = generate.prompt ?? modelConfiguration.defaultPrompt
+        let prompt = try? generate.resolvePrompt(configuration: modelConfiguration) ?? modelConfiguration.defaultPrompt
         let images = image.map { UserInput.Image.url($0) }
         var input = UserInput(prompt: prompt, images: images)
 

--- a/Tools/llm-tool/LLMTool.swift
+++ b/Tools/llm-tool/LLMTool.swift
@@ -212,7 +212,9 @@ struct EvaluateCommand: AsyncParsableCommand {
 
     private func userInput(modelConfiguration: ModelConfiguration) -> UserInput {
         // prompt and images
-        let prompt = (try? generate.resolvePrompt(configuration: modelConfiguration)) ?? modelConfiguration.defaultPrompt
+        let prompt =
+            (try? generate.resolvePrompt(configuration: modelConfiguration))
+            ?? modelConfiguration.defaultPrompt
         let images = image.map { UserInput.Image.url($0) }
         var input = UserInput(prompt: prompt, images: images)
 

--- a/Tools/llm-tool/LLMTool.swift
+++ b/Tools/llm-tool/LLMTool.swift
@@ -212,7 +212,7 @@ struct EvaluateCommand: AsyncParsableCommand {
 
     private func userInput(modelConfiguration: ModelConfiguration) -> UserInput {
         // prompt and images
-        let prompt = try? generate.resolvePrompt(configuration: modelConfiguration) ?? modelConfiguration.defaultPrompt
+        let prompt = (try? generate.resolvePrompt(configuration: modelConfiguration)) ?? modelConfiguration.defaultPrompt
         let images = image.map { UserInput.Image.url($0) }
         var input = UserInput(prompt: prompt, images: images)
 


### PR DESCRIPTION
According to [the documentation](https://github.com/ml-explore/mlx-swift-examples/blob/8cdc4a065a153bd0af7f1309eb8d5418f014e046/Tools/llm-tool/LLMTool.swift#L51), `@` can be used to indicate input files for the prompt, but `resolvePrompt` was never being called.

Tested before / after with

```bash
./mlx-run llm-tool eval --model mlx-community/gemma-2-2b-it-4bit --prompt @prompt.txt
```
