### PR TITLE
Revert conditional dependency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -33,6 +33,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/apple/swift-async-algorithms", .upToNextMinor(from: "1.0.0")),
+        .package(url: "https://github.com/1024jp/GzipSwift", "6.0.1" ... "6.0.1"),  // Only needed by MLXMNIST
     ],
     targets: [
         .target(
@@ -141,13 +142,6 @@ let package = Package(
         ),
     ]
 )
-
-// Add GzipSwift dependency only when building MLXMNIST
-if package.targets.contains(where: { $0.name == "MLXMNIST" }) {
-    package.dependencies.append(
-        .package(url: "https://github.com/1024jp/GzipSwift", "6.0.1" ... "6.0.1")
-    )
-}
 
 if Context.environment["MLX_SWIFT_BUILD_DOC"] == "1"
     || Context.environment["SPI_GENERATE_DOCS"] == "1"


### PR DESCRIPTION
Sorry, it looks like my attempt at conditionally including Gzip didn't work, since the condition was always satisfied. So I've moved it back to the dependencies for all targets. I couldn't find any other way to conditionally include it, but I think unused dependencies aren't included in compiled apps anyway.