### PR TITLE
Add video support for Qwen2-VL

### DIFF
--- a/Applications/VLMEval/ContentView.swift
+++ b/Applications/VLMEval/ContentView.swift
@@ -1,5 +1,6 @@
 // Copyright 2024 Apple Inc.
 
+import AVKit
 import CoreImage
 import MLX
 import MLXLMCommon
@@ -19,12 +20,28 @@ struct ContentView: View {
     @State var llm = VLMEvaluator()
     @Environment(DeviceStat.self) private var deviceStat
 
-    @State private var selectedImage: PlatformImage? = nil
+    @State private var selectedImage: PlatformImage? = nil {
+        didSet {
+            if selectedImage != nil {
+                selectedVideoURL = nil
+                player = nil
+            }
+        }
+    }
+    @State private var selectedVideoURL: URL? = nil {
+        didSet {
+            if let selectedVideoURL {
+                player = AVPlayer(url: selectedVideoURL)
+                selectedImage = nil
+            }
+        }
+    }
     @State private var showingImagePicker = false
     @State private var selectedItem: PhotosPickerItem? = nil
+    @State private var player: AVPlayer? = nil
 
     private var currentImageURL: URL? {
-        selectedImage == nil
+        selectedImage == nil && selectedVideoURL == nil
             ? URL(
                 string:
                     "https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/bee.jpg"
@@ -46,13 +63,13 @@ struct ContentView: View {
                 VStack {
                     if let selectedImage {
                         Group {
-                            #if os(iOS)
-                                Image(uiImage: selectedImage)
-                                    .resizable()
-                            #else
-                                Image(nsImage: selectedImage)
-                                    .resizable()
-                            #endif
+#if os(iOS)
+                            Image(uiImage: selectedImage)
+                                .resizable()
+#else
+                            Image(nsImage: selectedImage)
+                                .resizable()
+#endif
                         }
                         .scaledToFit()
                         .cornerRadius(12)
@@ -74,54 +91,65 @@ struct ContentView: View {
                                 EmptyView()
                             }
                         }
+                    } else if let player {
+                        VideoPlayer(player: player)
+                            .scaledToFit()
+                            .frame(maxHeight: 300)
+                            .cornerRadius(12)
                     }
 
                     HStack {
-                        #if os(iOS)
-                            PhotosPicker(
-                                selection: $selectedItem,
-                                matching: .images
-                            ) {
-                                Label("Select Image", systemImage: "photo.badge.plus")
-                            }
-                            .onChange(of: selectedItem) {
-                                Task {
-                                    if let data = try? await selectedItem?.loadTransferable(
-                                        type: Data.self)
-                                    {
-                                        selectedImage = PlatformImage(data: data)
-                                    }
+#if os(iOS)
+                        PhotosPicker(
+                            selection: $selectedItem,
+                            matching: PHPickerFilter.any(of: [PHPickerFilter.images, PHPickerFilter.videos])
+                        ) {
+                            Label("Select Image/Video", systemImage: "photo.badge.plus")
+                        }
+                        .onChange(of: selectedItem) {
+                            Task {
+                                if let video = try? await selectedItem?.loadTransferable(type: TransferableVideo.self) {
+                                    selectedVideoURL = video.url
+                                } else if let data = try? await selectedItem?.loadTransferable(
+                                    type: Data.self)
+                                {
+                                    selectedImage = PlatformImage(data: data)
                                 }
                             }
-                        #else
-                            Button("Select Image") {
-                                showingImagePicker = true
-                            }
-                            .fileImporter(
-                                isPresented: $showingImagePicker,
-                                allowedContentTypes: [.image]
-                            ) { result in
-                                switch result {
-                                case .success(let file):
-                                    Task { @MainActor in
-                                        do {
-                                            let data = try loadImage(from: file)
-                                            if let image = PlatformImage(data: data) {
-                                                selectedImage = image
-                                            } else {
-                                                print("Failed to create image from data")
+                        }
+#else
+                        Button("Select Image/Video") {
+                            showingImagePicker = true
+                        }
+                        .fileImporter(
+                            isPresented: $showingImagePicker,
+                            allowedContentTypes: [.image, .movie]
+                        ) { result in
+                            switch result {
+                            case .success(let file):
+                                Task { @MainActor in
+                                    do {
+                                        let data = try loadData(from: file)
+                                        if let image = PlatformImage(data: data) {
+                                            selectedImage = image
+                                        } else if let fileType = UTType(filenameExtension: file.pathExtension), fileType.conforms(to: .movie) {
+                                            if let sandboxURL = try? loadVideoToSandbox(from: file) {
+                                                selectedVideoURL = sandboxURL
                                             }
-                                        } catch {
-                                            print(
-                                                "Failed to load image: \(error.localizedDescription)"
-                                            )
+                                        } else {
+                                            print("Failed to create image from data")
                                         }
+                                    } catch {
+                                        print(
+                                            "Failed to load image: \(error.localizedDescription)"
+                                        )
                                     }
-                                case .failure(let error):
-                                    print(error.localizedDescription)
                                 }
+                            case .failure(let error):
+                                print(error.localizedDescription)
                             }
-                        #endif
+                        }
+#endif
 
                         if selectedImage != nil {
                             Button("Clear", role: .destructive) {
@@ -161,18 +189,18 @@ struct ContentView: View {
                 TextField("prompt", text: $prompt)
                     .onSubmit(generate)
                     .disabled(llm.running)
-                    #if os(visionOS)
-                        .textFieldStyle(.roundedBorder)
-                    #endif
+#if os(visionOS)
+                    .textFieldStyle(.roundedBorder)
+#endif
                 Button("generate", action: generate)
                     .disabled(llm.running)
             }
         }
-        #if os(visionOS)
-            .padding(40)
-        #else
-            .padding()
-        #endif
+#if os(visionOS)
+        .padding(40)
+#else
+        .padding()
+#endif
         .toolbar {
             ToolbarItem {
                 Label(
@@ -183,11 +211,11 @@ struct ContentView: View {
                 .padding(.horizontal)
                 .help(
                     Text(
-                        """
-                        Active Memory: \(deviceStat.gpuUsage.activeMemory.formatted(.byteCount(style: .memory)))/\(GPU.memoryLimit.formatted(.byteCount(style: .memory)))
-                        Cache Memory: \(deviceStat.gpuUsage.cacheMemory.formatted(.byteCount(style: .memory)))/\(GPU.cacheLimit.formatted(.byteCount(style: .memory)))
-                        Peak Memory: \(deviceStat.gpuUsage.peakMemory.formatted(.byteCount(style: .memory)))
-                        """
+                    """
+                    Active Memory: \(deviceStat.gpuUsage.activeMemory.formatted(.byteCount(style: .memory)))/\(GPU.memoryLimit.formatted(.byteCount(style: .memory)))
+                    Cache Memory: \(deviceStat.gpuUsage.cacheMemory.formatted(.byteCount(style: .memory)))/\(GPU.cacheLimit.formatted(.byteCount(style: .memory)))
+                    Peak Memory: \(deviceStat.gpuUsage.peakMemory.formatted(.byteCount(style: .memory)))
+                    """
                     )
                 )
             }
@@ -214,30 +242,34 @@ struct ContentView: View {
             if let selectedImage = selectedImage {
                 #if os(iOS)
                     let ciImage = CIImage(image: selectedImage)
-                    await llm.generate(prompt: prompt, image: ciImage ?? CIImage())
+                await llm.generate(prompt: prompt, image: ciImage ?? CIImage(), videoURL: nil)
                 #else
                     if let cgImage = selectedImage.cgImage(
                         forProposedRect: nil, context: nil, hints: nil)
                     {
                         let ciImage = CIImage(cgImage: cgImage)
-                        await llm.generate(prompt: prompt, image: ciImage)
+                        await llm.generate(prompt: prompt, image: ciImage, videoURL: nil)
                     }
                 #endif
             } else if let imageURL = currentImageURL {
                 do {
                     let (data, _) = try await URLSession.shared.data(from: imageURL)
                     if let ciImage = CIImage(data: data) {
-                        await llm.generate(prompt: prompt, image: ciImage)
+                        await llm.generate(prompt: prompt, image: ciImage, videoURL: nil)
                     }
                 } catch {
                     print("Failed to load image: \(error.localizedDescription)")
+                }
+            } else {
+                if let videoURL = selectedVideoURL {
+                    await llm.generate(prompt: prompt, image: nil, videoURL: videoURL)
                 }
             }
         }
     }
 
     #if os(macOS)
-        private func loadImage(from url: URL) throws -> Data {
+        private func loadData(from url: URL) throws -> Data {
             guard url.startAccessingSecurityScopedResource() else {
                 throw NSError(
                     domain: "FileAccess", code: -1,
@@ -246,6 +278,17 @@ struct ContentView: View {
             defer { url.stopAccessingSecurityScopedResource() }
             return try Data(contentsOf: url)
         }
+
+    private func loadVideoToSandbox(from url: URL) throws -> URL {
+        guard url.startAccessingSecurityScopedResource() else {
+            throw NSError(
+                domain: "FileAccess", code: -1,
+                userInfo: [NSLocalizedDescriptionKey: "Failed to access the file."])
+        }
+        defer { url.stopAccessingSecurityScopedResource() }
+        let sandboxURL = try SandboxFileTransfer.transferFileToTemp(from: url)
+        return sandboxURL
+    }
     #endif
 
     private func copyToClipboard(_ string: String) {
@@ -318,7 +361,7 @@ class VLMEvaluator {
         }
     }
 
-    func generate(prompt: String, image: CIImage) async {
+    func generate(prompt: String, image: CIImage?, videoURL: URL?) async {
         guard !running else { return }
 
         running = true
@@ -331,7 +374,9 @@ class VLMEvaluator {
             MLXRandom.seed(UInt64(Date.timeIntervalSinceReferenceDate * 1000))
 
             let result = try await modelContainer.perform { context in
-                var userInput = UserInput(prompt: prompt, images: [.ciImage(image)])
+                let images: [UserInput.Image] = image != nil ? [.ciImage(image!)] : []
+                let videos: [UserInput.Video] = videoURL != nil ? [.url(videoURL!)] : []
+                var userInput = UserInput(prompt: prompt, images: images, videos: videos)
                 userInput.processing.resize = .init(width: 448, height: 448)
 
                 let input = try await context.processor.prepare(input: userInput)
@@ -368,5 +413,34 @@ class VLMEvaluator {
         }
 
         running = false
+    }
+}
+
+#if os(iOS)
+struct TransferableVideo: Transferable {
+    let url: URL
+
+    static var transferRepresentation: some TransferRepresentation {
+        FileRepresentation(contentType: .movie) { movie in
+            SentTransferredFile(movie.url)
+        } importing: { received in
+            let sandboxURL = try SandboxFileTransfer.transferFileToTemp(from: received.file)
+            return .init(url: sandboxURL)
+        }
+    }
+}
+#endif
+
+struct SandboxFileTransfer {
+    static func transferFileToTemp(from sourceURL: URL) throws -> URL {
+        let tempDir = FileManager.default.temporaryDirectory
+        let sandboxURL = tempDir.appendingPathComponent(sourceURL.lastPathComponent)
+
+        if FileManager.default.fileExists(atPath: sandboxURL.path()) {
+            try FileManager.default.removeItem(at: sandboxURL)
+        }
+
+        try FileManager.default.copyItem(at: sourceURL, to: sandboxURL)
+        return sandboxURL
     }
 }

--- a/Libraries/MLXLMCommon/LanguageModel.swift
+++ b/Libraries/MLXLMCommon/LanguageModel.swift
@@ -99,7 +99,10 @@ public struct LMInput {
         self.init(text: .init(tokens: tokens, mask: mask))
     }
 
-    public init(text: LMInput.Text, image: LMInput.ProcessedImage? = nil, video: LMInput.ProcessedVideo? = nil) {
+    public init(
+        text: LMInput.Text, image: LMInput.ProcessedImage? = nil,
+        video: LMInput.ProcessedVideo? = nil
+    ) {
         self.text = text
         self.image = image
         self.video = video

--- a/Libraries/MLXLMCommon/LanguageModel.swift
+++ b/Libraries/MLXLMCommon/LanguageModel.swift
@@ -37,6 +37,7 @@ public struct THW: Sendable {
 public struct LMInput {
     public let text: Text
     public let image: ProcessedImage?
+    public let video: ProcessedVideo?
 
     /// Representation of tokenized input text.
     public struct Text {
@@ -79,13 +80,29 @@ public struct LMInput {
         }
     }
 
+    /// Representation of prepared input video(s).
+    /// For now, this is virtually identical to ProcessedImage.
+    public struct ProcessedVideo {
+
+        public let pixels: MLXArray
+        public let videoGridThw: [THW]?
+
+        public init(
+            pixels: MLXArray, videoGridThw: [THW]? = nil
+        ) {
+            self.pixels = pixels
+            self.videoGridThw = videoGridThw
+        }
+    }
+
     public init(tokens: MLXArray, mask: MLXArray? = nil) {
         self.init(text: .init(tokens: tokens, mask: mask))
     }
 
-    public init(text: LMInput.Text, image: LMInput.ProcessedImage? = nil) {
+    public init(text: LMInput.Text, image: LMInput.ProcessedImage? = nil, video: LMInput.ProcessedVideo? = nil) {
         self.text = text
         self.image = image
+        self.video = video
     }
 }
 

--- a/Libraries/MLXLMCommon/UserInput.swift
+++ b/Libraries/MLXLMCommon/UserInput.swift
@@ -1,9 +1,9 @@
 // Copyright © 2024 Apple Inc.
 
+import AVFoundation
 import CoreImage
 import Foundation
 import MLX
-import AVFoundation
 
 /// Container for raw user input.
 ///

--- a/Libraries/MLXLMCommon/UserInput.swift
+++ b/Libraries/MLXLMCommon/UserInput.swift
@@ -3,6 +3,7 @@
 import CoreImage
 import Foundation
 import MLX
+import AVFoundation
 
 /// Container for raw user input.
 ///
@@ -30,6 +31,20 @@ public struct UserInput: Sendable {
                 return text
             case .messages(let messages):
                 return messages.map { $0.description }.joined(separator: "\n")
+            }
+        }
+    }
+
+    public enum Video: Sendable {
+        case avAsset(AVAsset)
+        case url(URL)
+
+        public func asAVAsset() -> AVAsset {
+            switch self {
+            case .avAsset(let asset):
+                return asset
+            case .url(let url):
+                return AVAsset(url: url)
             }
         }
     }
@@ -109,11 +124,13 @@ public struct UserInput: Sendable {
 
     public var prompt: Prompt
     public var images = [Image]()
+    public var videos = [Video]()
     public var processing: Processing = .init()
 
-    public init(prompt: String, images: [Image] = [Image]()) {
+    public init(prompt: String, images: [Image] = [Image](), videos: [Video] = [Video]()) {
         self.prompt = .text(prompt)
         self.images = images
+        self.videos = videos
     }
 
     public init(messages: [[String: String]], images: [Image] = [Image]()) {

--- a/Libraries/MLXVLM/MediaProcessing.swift
+++ b/Libraries/MLXVLM/MediaProcessing.swift
@@ -1,5 +1,6 @@
 // Copyright © 2024 Apple Inc.
 
+import AVFoundation
 import CoreImage.CIFilterBuiltins
 import MLX
 import MLXLMCommon
@@ -153,5 +154,48 @@ public enum MediaProcessing {
         }
 
         return image
+    }
+
+    static func asCIImageSequence(_ asset: AVAsset, samplesPerSecond: Int) async throws -> [CIImage] {
+        // Use AVAssetImageGenerator to extract frames
+        let generator = AVAssetImageGenerator(asset: asset)
+        generator.appliesPreferredTrackTransform = true
+        generator.requestedTimeToleranceBefore = .zero
+        generator.requestedTimeToleranceAfter = .zero
+
+        // Calculate the time values we want to sample
+        guard let duration = try? await asset.load(.duration) else {
+            throw NSError(
+                domain: "MediaProcessing", code: -1,
+                userInfo: [NSLocalizedDescriptionKey: "Failed to load the asset's duration"])
+        }
+
+        let durationInSeconds = duration.seconds
+        let samplesPerSecond = Double(samplesPerSecond)
+        let secondsPerSample = 1.0 / samplesPerSecond
+        let totalFramesToSample = durationInSeconds * samplesPerSecond
+        let durationTimeValue = duration.value
+        let sampledTimeValues = MLXArray.linspace(0, durationTimeValue, count: Int(totalFramesToSample)).asArray(Int64.self)
+
+        // Construct a CMTime using the sampled CMTimeValue's and the asset's timescale
+        let timescale = duration.timescale
+        let sampledTimes = sampledTimeValues.map { CMTime(value: $0, timescale: timescale) }
+
+        // Collect the frames
+        var ciImages: [CIImage] = []
+        for sampledTime in sampledTimes {
+            guard let generatedImage = try? await generator.image(at: sampledTime) else {
+                continue
+            }
+            guard let colorSpace = CGColorSpace(name: CGColorSpace.sRGB), let convertedImage = generatedImage.image.copy(colorSpace: colorSpace) else {
+                throw NSError(
+                    domain: "MediaProcessing", code: -1,
+                    userInfo: [NSLocalizedDescriptionKey: "Failed to convert the color space of the video frame"])
+            }
+            let ciImage = CIImage(cgImage: convertedImage)
+            ciImages.append(ciImage)
+        }
+        
+        return ciImages
     }
 }


### PR DESCRIPTION
**Overview**
This PR adds video processing capabilities to Qwen2-VL by:
- Extending UserInput and LMInput to handle video input
- Adding frame extraction functionality in the MediaProcessing module
- Implementing video processing support and necessary tokens in Qwen2-VL

**Performance**
- Hardware: MacBook Pro (M2 Pro, 32GB RAM)
- Test Video: 30 seconds, 320×180 resolution (without resizing to 448x448 in ContentView)

**Results**
The whole inference procedure, including frame extraction and processing:
- This implementation: ~6.5 seconds
- [Reference implementation](https://github.com/awni/mlx-vlm/tree/video): ~5 seconds



