### PR TITLE
Add argument for extra EOS token to llm-tool

### DIFF
--- a/Libraries/MLXLMCommon/ModelConfiguration.swift
+++ b/Libraries/MLXLMCommon/ModelConfiguration.swift
@@ -31,10 +31,10 @@ public struct ModelConfiguration: Sendable {
     public let overrideTokenizer: String?
 
     /// A reasonable default prompt for the model
-    public let defaultPrompt: String
+    public var defaultPrompt: String
 
     /// Additional tokens to use for end of string
-    public let extraEOSTokens: Set<String>
+    public var extraEOSTokens: Set<String>
 
     public init(
         id: String, tokenizerId: String? = nil, overrideTokenizer: String? = nil,

--- a/Libraries/MLXLMCommon/ModelContainer.swift
+++ b/Libraries/MLXLMCommon/ModelContainer.swift
@@ -32,12 +32,11 @@ import Tokenizers
 /// }
 /// ```
 public actor ModelContainer {
-    let context: ModelContext
-    nonisolated public let configuration: ModelConfiguration
+    var context: ModelContext
+    public var configuration: ModelConfiguration { context.configuration }
 
     public init(context: ModelContext) {
         self.context = context
-        self.configuration = context.configuration
     }
 
     /// Perform an action on the model and/or tokenizer.  Callers _must_ eval any `MLXArray` before returning as
@@ -75,4 +74,9 @@ public actor ModelContainer {
         try await action(context, values)
     }
 
+    /// Update the owned `ModelContext`.
+    /// - Parameter action: update action
+    public func update(_ action: @Sendable (inout ModelContext) -> Void) {
+        action(&context)
+    }
 }

--- a/Libraries/MLXLMCommon/ModelFactory.swift
+++ b/Libraries/MLXLMCommon/ModelFactory.swift
@@ -22,10 +22,10 @@ public enum ModelFactoryError: Error {
 /// See also ``ModelFactory/loadContainer(hub:configuration:progressHandler:)`` and
 /// ``ModelContainer``.
 public struct ModelContext {
-    public let configuration: ModelConfiguration
-    public let model: any LanguageModel
-    public let processor: any UserInputProcessor
-    public let tokenizer: Tokenizer
+    public var configuration: ModelConfiguration
+    public var model: any LanguageModel
+    public var processor: any UserInputProcessor
+    public var tokenizer: Tokenizer
 
     public init(
         configuration: ModelConfiguration, model: any LanguageModel,

--- a/Tools/llm-tool/LoraCommands.swift
+++ b/Tools/llm-tool/LoraCommands.swift
@@ -48,7 +48,7 @@ struct LoRAModelArguments: ParsableArguments, Sendable {
         // convert some of the Linear layers to LoRALinear
         await modelContainer.perform { context in
             guard let lora = context.model as? LoRAModel else {
-                fatalError("Model \(modelContainer.configuration.name) is not a LoRAModel")
+                fatalError("Model \(context.configuration.name) is not a LoRAModel")
             }
             LoRATrain.convert(model: context.model, layers: lora.loraLinearLayers(loraLayers))
         }
@@ -197,7 +197,7 @@ struct LoRAFuseCommand: AsyncParsableCommand {
         // fuse them back into Linear/QuantizedLinear
         await modelContainer.perform { [args, deQuantize] context in
             guard let lora = context.model as? LoRAModel else {
-                fatalError("Model \(modelContainer.configuration.name) is not a LoRAModel")
+                fatalError("Model \(context.configuration.name) is not a LoRAModel")
             }
 
             LoRATrain.fuse(
@@ -207,7 +207,7 @@ struct LoRAFuseCommand: AsyncParsableCommand {
 
         // make the new directory and copy files from source model
         try FileManager.default.createDirectory(at: outputURL, withIntermediateDirectories: true)
-        let inputURL = modelContainer.configuration.modelDirectory()
+        let inputURL = await modelContainer.configuration.modelDirectory()
         let enumerator = FileManager.default.enumerator(
             at: inputURL, includingPropertiesForKeys: nil)!
         for case let url as URL in enumerator {
@@ -296,7 +296,8 @@ struct LoRAEvalCommand: AsyncParsableCommand {
 
         memory.start()
 
-        let prompt = generate.prompt ?? modelContainer.configuration.defaultPrompt
+        let defaultPrompt = await modelContainer.configuration.defaultPrompt
+        let prompt = generate.prompt ?? defaultPrompt
 
         if !generate.quiet {
             print("Starting generation ...")

--- a/mlx-swift-examples.xcodeproj/xcshareddata/xcschemes/llm-tool.xcscheme
+++ b/mlx-swift-examples.xcodeproj/xcshareddata/xcschemes/llm-tool.xcscheme
@@ -56,12 +56,12 @@
             isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "--prompt &apos;Describe the image in English.&apos; --image https://www.gstatic.com/webp/gallery/1.webp"
+            argument = "--model microsoft/Phi-4-mini-instruct --prompt &quot;Why is the sky blue?&quot; --extra-eos-token &quot;&lt;|end|&gt;&quot;"
             isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "--model mlx-community/Qwen2-VL-2B-Instruct-4bit"
-            isEnabled = "NO">
+            argument = "--model mlx-community/Qwen2-VL-2B-Instruct-4bit --prompt &apos;Describe the image in English.&apos; --image https://www.gstatic.com/webp/gallery/1.webp"
+            isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "--repetition-penalty 1.2"
@@ -89,7 +89,7 @@
          </CommandLineArgument>
          <CommandLineArgument
             argument = "--prompt &apos;Why is the sky blue?&apos;"
-            isEnabled = "YES">
+            isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "--model mlx-community/Mistral-7B-v0.1-hf-4bit-mlx"
@@ -97,7 +97,7 @@
          </CommandLineArgument>
          <CommandLineArgument
             argument = "--model mlx-community/Llama-3.2-1B-Instruct-4bit"
-            isEnabled = "YES">
+            isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "--model mlx-community/phi-2-hf-4bit-mlx"


### PR DESCRIPTION
I added an argument for the extra EOS token to match the Python implementation and also improved the console output during loading.

Maybe we should rethink how llm-tool is implemented, since this solution is a bit unwieldy.