### PR TITLE
provide public accessors for ModelConfigurations from registries

### DIFF
--- a/Libraries/Embedders/Models.swift
+++ b/Libraries/Embedders/Models.swift
@@ -83,6 +83,12 @@ public struct ModelConfiguration: Sendable {
             return ModelConfiguration(id: id)
         }
     }
+
+    @MainActor
+    public static var models: some Collection<ModelConfiguration> & Sendable {
+        bootstrap()
+        return Self.registry.values
+    }
 }
 
 extension ModelConfiguration {

--- a/Libraries/MLXLLM/LLMModelFactory.swift
+++ b/Libraries/MLXLLM/LLMModelFactory.swift
@@ -226,6 +226,12 @@ public class ModelRegistry: @unchecked Sendable {
             }
         }
     }
+
+    public var models: some Collection<ModelConfiguration> & Sendable {
+        lock.withLock {
+            return registry.values
+        }
+    }
 }
 
 private struct LLMUserInputProcessor: UserInputProcessor {

--- a/Libraries/MLXVLM/VLMModelFactory.swift
+++ b/Libraries/MLXVLM/VLMModelFactory.swift
@@ -186,6 +186,12 @@ public class ModelRegistry: @unchecked Sendable {
             }
         }
     }
+
+    public var models: some Collection<ModelConfiguration> & Sendable {
+        lock.withLock {
+            return registry.values
+        }
+    }
 }
 
 /// Factory for creating new LLMs.


### PR DESCRIPTION
Added public accessors for getting a list of registered ModelConfigurations. Would be nice to standardize these eventually.