### PR TITLE
Make LLMModelFactory and VLMModelFactory inits public

### DIFF
--- a/Libraries/MLXLLM/LLMModelFactory.swift
+++ b/Libraries/MLXLLM/LLMModelFactory.swift
@@ -274,13 +274,19 @@ private struct LLMUserInputProcessor: UserInputProcessor {
 /// ```
 public class LLMModelFactory: ModelFactory {
 
-    public static let shared = LLMModelFactory()
+    public init(typeRegistry: ModelTypeRegistry, modelRegistry: ModelRegistry) {
+        self.typeRegistry = typeRegistry
+        self.modelRegistry = modelRegistry
+    }
+
+    /// Shared instance with default behavior.
+    public static let shared = LLMModelFactory(typeRegistry: .init(), modelRegistry: .init())
 
     /// registry of model type, e.g. configuration value `llama` -> configuration and init methods
-    public let typeRegistry = ModelTypeRegistry()
+    public let typeRegistry: ModelTypeRegistry
 
     /// registry of model id to configuration, e.g. `mlx-community/Llama-3.2-3B-Instruct-4bit`
-    public let modelRegistry = ModelRegistry()
+    public let modelRegistry: ModelRegistry
 
     public func configuration(id: String) -> ModelConfiguration {
         modelRegistry.configuration(id: id)

--- a/Libraries/MLXLLM/LLMModelFactory.swift
+++ b/Libraries/MLXLLM/LLMModelFactory.swift
@@ -59,8 +59,6 @@ public class ModelTypeRegistry: @unchecked Sendable {
     private let lock = NSLock()
     private var creators: [String: @Sendable (URL) throws -> any LanguageModel]
 
-
-
     /// Add a new model to the type registry.
     public func registerModelType(
         _ type: String, creator: @Sendable @escaping (URL) throws -> any LanguageModel
@@ -105,7 +103,7 @@ public class ModelRegistry: @unchecked Sendable {
     public static let shared = ModelRegistry(modelConfigurations: all())
 
     private let lock = NSLock()
-    private var registry: Dictionary<String, ModelConfiguration>
+    private var registry: [String: ModelConfiguration]
 
     static public let smolLM_135M_4bit = ModelConfiguration(
         id: "mlx-community/SmolLM-135M-Instruct-4bit",

--- a/Libraries/MLXLLM/LLMModelFactory.swift
+++ b/Libraries/MLXLLM/LLMModelFactory.swift
@@ -72,8 +72,21 @@ public class ModelTypeRegistry: @unchecked Sendable {
 /// implementation, if needed.
 public class ModelRegistry: @unchecked Sendable {
 
+    /// Creates an empty registry.
+    public init() {
+        self.registry = Dictionary()
+    }
+
+    /// Creates a new registry with from given model configurations.
+    public init(modelConfigurations: [ModelConfiguration]) {
+        self.registry = Dictionary(uniqueKeysWithValues: modelConfigurations.map { ($0.name, $0) })
+    }
+
+    /// Shared instance with default model configurations.
+    public static let shared = ModelRegistry(modelConfigurations: all())
+
     private let lock = NSLock()
-    private var registry = Dictionary(uniqueKeysWithValues: all().map { ($0.name, $0) })
+    private var registry: Dictionary<String, ModelConfiguration>
 
     static public let smolLM_135M_4bit = ModelConfiguration(
         id: "mlx-community/SmolLM-135M-Instruct-4bit",
@@ -280,7 +293,7 @@ public class LLMModelFactory: ModelFactory {
     }
 
     /// Shared instance with default behavior.
-    public static let shared = LLMModelFactory(typeRegistry: .init(), modelRegistry: .init())
+    public static let shared = LLMModelFactory(typeRegistry: .init(), modelRegistry: .shared)
 
     /// registry of model type, e.g. configuration value `llama` -> configuration and init methods
     public let typeRegistry: ModelTypeRegistry

--- a/Libraries/MLXVLM/VLMModelFactory.swift
+++ b/Libraries/MLXVLM/VLMModelFactory.swift
@@ -90,20 +90,28 @@ public class ModelTypeRegistry: @unchecked Sendable {
 
 public class ProcessorTypeRegistry: @unchecked Sendable {
 
+    /// Creates an empty registry
+    public init() {
+        self.creators = [:]
+    }
+
+    /// Shared instance with default processor types.
+    public static let shared: ProcessorTypeRegistry = {
+        let instance = ProcessorTypeRegistry()
+
+        instance.registerProcessorType("PaliGemmaProcessor", creator: create(PaliGemmaProcessorConfiguration.self, PaligGemmaProcessor.init))
+        instance.registerProcessorType("Qwen2VLProcessor", creator: create(Qwen2VLProcessorConfiguration.self, Qwen2VLProcessor.init))
+        instance.registerProcessorType("Idefics3Processor", creator: create(Idefics3ProcessorConfiguration.self, Idefics3Processor.init))
+
+        return instance
+    }()
+
     // Note: using NSLock as we have very small (just dictionary get/set)
     // critical sections and expect no contention.  this allows the methods
     // to remain synchronous.
     private let lock = NSLock()
 
-    private var creators:
-        [String: @Sendable (URL, any Tokenizer) throws -> any UserInputProcessor] = [
-            "PaliGemmaProcessor": create(
-                PaliGemmaProcessorConfiguration.self, PaligGemmaProcessor.init),
-            "Qwen2VLProcessor": create(
-                Qwen2VLProcessorConfiguration.self, Qwen2VLProcessor.init),
-            "Idefics3Processor": create(
-                Idefics3ProcessorConfiguration.self, Idefics3Processor.init),
-        ]
+    private var creators: [String: @Sendable (URL, any Tokenizer) throws -> any UserInputProcessor]
 
     /// Add a new model to the type registry.
     public func registerProcessorType(
@@ -224,7 +232,7 @@ public class VLMModelFactory: ModelFactory {
     }
 
     /// Shared instance with default behavior.
-    public static let shared = VLMModelFactory(typeRegistry: .init(), processorRegistry: .init(), modelRegistry: .shared)
+    public static let shared = VLMModelFactory(typeRegistry: .init(), processorRegistry: .shared, modelRegistry: .shared)
 
     /// registry of model type, e.g. configuration value `paligemma` -> configuration and init methods
     public let typeRegistry: ModelTypeRegistry

--- a/Libraries/MLXVLM/VLMModelFactory.swift
+++ b/Libraries/MLXVLM/VLMModelFactory.swift
@@ -140,6 +140,18 @@ public class ProcessorTypeRegistry: @unchecked Sendable {
 /// swift-tokenizers code handles a good chunk of that and this is a place to augment that
 /// implementation, if needed.
 public class ModelRegistry: @unchecked Sendable {
+    /// Creates an empty registry.
+    public init() {
+        registry = Dictionary()
+    }
+
+    /// Creates a new registry with from given model configurations.
+    public init(modelConfigurations: [ModelConfiguration]) {
+        registry = Dictionary(uniqueKeysWithValues: modelConfigurations.map { ($0.name, $0) })
+    }
+
+    /// Shared instance with default model configurations.
+    public static let shared = ModelRegistry(modelConfigurations: all())
 
     private let lock = NSLock()
     private var registry = Dictionary(
@@ -212,7 +224,7 @@ public class VLMModelFactory: ModelFactory {
     }
 
     /// Shared instance with default behavior.
-    public static let shared = VLMModelFactory(typeRegistry: .init(), processorRegistry: .init(), modelRegistry: .init())
+    public static let shared = VLMModelFactory(typeRegistry: .init(), processorRegistry: .init(), modelRegistry: .shared)
 
     /// registry of model type, e.g. configuration value `paligemma` -> configuration and init methods
     public let typeRegistry: ModelTypeRegistry

--- a/Libraries/MLXVLM/VLMModelFactory.swift
+++ b/Libraries/MLXVLM/VLMModelFactory.swift
@@ -168,10 +168,7 @@ public class ModelRegistry: @unchecked Sendable {
     public static let shared = ModelRegistry(modelConfigurations: all())
 
     private let lock = NSLock()
-    private var registry = Dictionary(
-        uniqueKeysWithValues: all().map {
-            ($0.name, $0)
-        })
+    private var registry: Dictionary<String, ModelConfiguration>
 
     static public let paligemma3bMix448_8bit = ModelConfiguration(
         id: "mlx-community/paligemma-3b-mix-448-8bit",

--- a/Libraries/MLXVLM/VLMModelFactory.swift
+++ b/Libraries/MLXVLM/VLMModelFactory.swift
@@ -205,16 +205,23 @@ public class ModelRegistry: @unchecked Sendable {
 /// ```
 public class VLMModelFactory: ModelFactory {
 
-    public static let shared = VLMModelFactory()
+    public init(typeRegistry: ModelTypeRegistry, processorRegistry: ProcessorTypeRegistry, modelRegistry: ModelRegistry) {
+        self.typeRegistry = typeRegistry
+        self.processorRegistry = processorRegistry
+        self.modelRegistry = modelRegistry
+    }
+
+    /// Shared instance with default behavior.
+    public static let shared = VLMModelFactory(typeRegistry: .init(), processorRegistry: .init(), modelRegistry: .init())
 
     /// registry of model type, e.g. configuration value `paligemma` -> configuration and init methods
-    public let typeRegistry = ModelTypeRegistry()
+    public let typeRegistry: ModelTypeRegistry
 
     /// registry of input processor type, e.g. configuration value `PaliGemmaProcessor` -> configuration and init methods
-    public let processorRegistry = ProcessorTypeRegistry()
+    public let processorRegistry: ProcessorTypeRegistry
 
     /// registry of model id to configuration, e.g. `mlx-community/paligemma-3b-mix-448-8bit`
-    public let modelRegistry = ModelRegistry()
+    public let modelRegistry: ModelRegistry
 
     public func configuration(id: String) -> ModelConfiguration {
         modelRegistry.configuration(id: id)

--- a/Libraries/MLXVLM/VLMModelFactory.swift
+++ b/Libraries/MLXVLM/VLMModelFactory.swift
@@ -90,21 +90,27 @@ public class ModelTypeRegistry: @unchecked Sendable {
 
 public class ProcessorTypeRegistry: @unchecked Sendable {
 
-    /// Creates an empty registry
+    /// Creates an empty registry.
     public init() {
         self.creators = [:]
     }
 
+    /// Creates a registry with given creators.
+    public init(creators: [String: @Sendable (URL, any Tokenizer) throws -> any UserInputProcessor]) {
+        self.creators = creators
+    }
+
     /// Shared instance with default processor types.
-    public static let shared: ProcessorTypeRegistry = {
-        let instance = ProcessorTypeRegistry()
+    public static let shared: ProcessorTypeRegistry = .init(creators: all())
 
-        instance.registerProcessorType("PaliGemmaProcessor", creator: create(PaliGemmaProcessorConfiguration.self, PaligGemmaProcessor.init))
-        instance.registerProcessorType("Qwen2VLProcessor", creator: create(Qwen2VLProcessorConfiguration.self, Qwen2VLProcessor.init))
-        instance.registerProcessorType("Idefics3Processor", creator: create(Idefics3ProcessorConfiguration.self, Idefics3Processor.init))
-
-        return instance
-    }()
+    /// All predefined processor types.
+    private static func all() -> [String: @Sendable (URL, any Tokenizer) throws -> any UserInputProcessor] {
+        [
+             "PaliGemmaProcessor": create(PaliGemmaProcessorConfiguration.self, PaligGemmaProcessor.init),
+             "Qwen2VLProcessor": create(Qwen2VLProcessorConfiguration.self, Qwen2VLProcessor.init),
+             "Idefics3Processor": create(Idefics3ProcessorConfiguration.self, Idefics3Processor.init),
+         ]
+    }
 
     // Note: using NSLock as we have very small (just dictionary get/set)
     // critical sections and expect no contention.  this allows the methods

--- a/Libraries/MLXVLM/VLMModelFactory.swift
+++ b/Libraries/MLXVLM/VLMModelFactory.swift
@@ -114,7 +114,8 @@ public class ProcessorTypeRegistry: @unchecked Sendable {
     }
 
     /// Creates a registry with given creators.
-    public init(creators: [String: @Sendable (URL, any Tokenizer) throws -> any UserInputProcessor]) {
+    public init(creators: [String: @Sendable (URL, any Tokenizer) throws -> any UserInputProcessor])
+    {
         self.creators = creators
     }
 
@@ -122,12 +123,16 @@ public class ProcessorTypeRegistry: @unchecked Sendable {
     public static let shared: ProcessorTypeRegistry = .init(creators: all())
 
     /// All predefined processor types.
-    private static func all() -> [String: @Sendable (URL, any Tokenizer) throws -> any UserInputProcessor] {
+    private static func all() -> [String: @Sendable (URL, any Tokenizer) throws ->
+        any UserInputProcessor]
+    {
         [
-             "PaliGemmaProcessor": create(PaliGemmaProcessorConfiguration.self, PaligGemmaProcessor.init),
-             "Qwen2VLProcessor": create(Qwen2VLProcessorConfiguration.self, Qwen2VLProcessor.init),
-             "Idefics3Processor": create(Idefics3ProcessorConfiguration.self, Idefics3Processor.init),
-         ]
+            "PaliGemmaProcessor": create(
+                PaliGemmaProcessorConfiguration.self, PaligGemmaProcessor.init),
+            "Qwen2VLProcessor": create(Qwen2VLProcessorConfiguration.self, Qwen2VLProcessor.init),
+            "Idefics3Processor": create(
+                Idefics3ProcessorConfiguration.self, Idefics3Processor.init),
+        ]
     }
 
     // Note: using NSLock as we have very small (just dictionary get/set)
@@ -186,7 +191,7 @@ public class ModelRegistry: @unchecked Sendable {
     public static let shared = ModelRegistry(modelConfigurations: all())
 
     private let lock = NSLock()
-    private var registry: Dictionary<String, ModelConfiguration>
+    private var registry: [String: ModelConfiguration]
 
     static public let paligemma3bMix448_8bit = ModelConfiguration(
         id: "mlx-community/paligemma-3b-mix-448-8bit",
@@ -207,7 +212,7 @@ public class ModelRegistry: @unchecked Sendable {
         [
             paligemma3bMix448_8bit,
             qwen2VL2BInstruct4Bit,
-            smolvlminstruct4bit
+            smolvlminstruct4bit,
         ]
     }
 
@@ -247,14 +252,18 @@ public class ModelRegistry: @unchecked Sendable {
 /// ```
 public class VLMModelFactory: ModelFactory {
 
-    public init(typeRegistry: ModelTypeRegistry, processorRegistry: ProcessorTypeRegistry, modelRegistry: ModelRegistry) {
+    public init(
+        typeRegistry: ModelTypeRegistry, processorRegistry: ProcessorTypeRegistry,
+        modelRegistry: ModelRegistry
+    ) {
         self.typeRegistry = typeRegistry
         self.processorRegistry = processorRegistry
         self.modelRegistry = modelRegistry
     }
 
     /// Shared instance with default behavior.
-    public static let shared = VLMModelFactory(typeRegistry: .shared, processorRegistry: .shared, modelRegistry: .shared)
+    public static let shared = VLMModelFactory(
+        typeRegistry: .shared, processorRegistry: .shared, modelRegistry: .shared)
 
     /// registry of model type, e.g. configuration value `paligemma` -> configuration and init methods
     public let typeRegistry: ModelTypeRegistry


### PR DESCRIPTION
This PR makes LLMModelFactory and VLMModelFactory inits public.

The PR currently not ready and I want to discuss some cases:
1. I created `shared` instance on registry types. Is it a good approach? First, I thought `init()` should create default registry but I think it isn't a good approach because people going to expect an empty registry.
2. Currently, there are two `ModelRegistry` class which is same. I think we should merge these two to one on MLXLMCommon package. Maybe, we can make it as a base class and create `LLMRegistry` and `VLMRegistry` class separately as a subclass of `ModelRegistry`. (Same for `ModelTypeRegistry`)
3. I didn't make the changes but we may use `String(describing:)` for `ProcessorTypeRegistry` registration. For example, 
```swift
public func registerProcessorType<T>(
        _ type: T.Type,
        creator: @Sendable @escaping (
            URL,
            any Tokenizer
        ) throws -> any UserInputProcessor
    ) {
        let typeName = String(describing: type)
        lock.withLock {
            creators[typeName] = creator
        }
    }
```
This is just for showing but if we use `String(describing:)` it will prevent typos and make the library more type safe IMO.

In conclusion, I want to be sure is this approach is acceptable? If so, I will do the same for the remaining parts. 