### PR TITLE
Add contains(id:) method to AbstractModelRegistry and ModelFactory

### DIFF
--- a/Libraries/MLXLLM/LLMModelFactory.swift
+++ b/Libraries/MLXLLM/LLMModelFactory.swift
@@ -250,19 +250,6 @@ public class LLMModelFactory: ModelFactory {
     /// registry of model id to configuration, e.g. `mlx-community/Llama-3.2-3B-Instruct-4bit`
     public let modelRegistry: AbstractModelRegistry
 
-    /// Returns configuration from ``modelRegistry``.
-    ///
-    /// - Note: If the id doesn't exists in the configuration, this will return a new instance of it.
-    /// If you want to check if the configuration in model registry, you should use ``contains(id:)``.
-    public func configuration(id: String) -> ModelConfiguration {
-        modelRegistry.configuration(id: id)
-    }
-
-    /// Returns true if ``modelRegistry`` contains a model with the id. Otherwise, false.
-    public func contains(id: String) -> Bool {
-        modelRegistry.contains(id: id)
-    }
-
     public func _load(
         hub: HubApi, configuration: ModelConfiguration,
         progressHandler: @Sendable @escaping (Progress) -> Void

--- a/Libraries/MLXLLM/LLMModelFactory.swift
+++ b/Libraries/MLXLLM/LLMModelFactory.swift
@@ -250,8 +250,17 @@ public class LLMModelFactory: ModelFactory {
     /// registry of model id to configuration, e.g. `mlx-community/Llama-3.2-3B-Instruct-4bit`
     public let modelRegistry: AbstractModelRegistry
 
+    /// Returns configuration from ``modelRegistry``.
+    ///
+    /// - Note: If the id doesn't exists in the configuration, this will return a new instance of it.
+    /// If you want to check if the configuration in model registry, you should use ``contains(id:)``.
     public func configuration(id: String) -> ModelConfiguration {
         modelRegistry.configuration(id: id)
+    }
+
+    /// Returns true if ``modelRegistry`` contains a model with the id. Otherwise, false.
+    public func contains(id: String) -> Bool {
+        modelRegistry.contains(id: id)
     }
 
     public func _load(

--- a/Libraries/MLXLMCommon/ModelFactory.swift
+++ b/Libraries/MLXLMCommon/ModelFactory.swift
@@ -40,12 +40,7 @@ public struct ModelContext {
 
 public protocol ModelFactory: Sendable {
 
-    /// Resolve a model identifier, e.g. "mlx-community/Llama-3.2-3B-Instruct-4bit", into
-    /// a ``ModelConfiguration``.
-    ///
-    /// This will either create a new (mostly unconfigured) ``ModelConfiguration`` or
-    /// return a registered instance that matches the id.
-    func configuration(id: String) -> ModelConfiguration
+    var modelRegistry: AbstractModelRegistry { get }
 
     func _load(
         hub: HubApi, configuration: ModelConfiguration,
@@ -56,6 +51,28 @@ public protocol ModelFactory: Sendable {
         hub: HubApi, configuration: ModelConfiguration,
         progressHandler: @Sendable @escaping (Progress) -> Void
     ) async throws -> ModelContainer
+
+}
+
+extension ModelFactory {
+
+    /// Resolve a model identifier, e.g. "mlx-community/Llama-3.2-3B-Instruct-4bit", into
+    /// a ``ModelConfiguration``.
+    ///
+    /// This will either create a new (mostly unconfigured) ``ModelConfiguration`` or
+    /// return a registered instance that matches the id.
+    ///
+    /// - Note: If the id doesn't exists in the configuration, this will return a new instance of it.
+    /// If you want to check if the configuration in model registry, you should use ``contains(id:)``.
+    public func configuration(id: String) -> ModelConfiguration {
+        modelRegistry.configuration(id: id)
+    }
+
+    /// Returns true if ``modelRegistry`` contains a model with the id. Otherwise, false.
+    public func contains(id: String) -> Bool {
+        modelRegistry.contains(id: id)
+    }
+
 }
 
 extension ModelFactory {

--- a/Libraries/MLXLMCommon/Registries/AbstractModelRegistry.swift
+++ b/Libraries/MLXLMCommon/Registries/AbstractModelRegistry.swift
@@ -25,6 +25,10 @@ open class AbstractModelRegistry: @unchecked Sendable {
         }
     }
 
+    /// Returns configuration from ``modelRegistry``.
+    ///
+    /// - Note: If the id doesn't exists in the configuration, this will return a new instance of it.
+    /// If you want to check if the configuration in model registry, you should use ``contains(id:)``.
     public func configuration(id: String) -> ModelConfiguration {
         lock.withLock {
             if let c = registry[id] {
@@ -32,6 +36,13 @@ open class AbstractModelRegistry: @unchecked Sendable {
             } else {
                 return ModelConfiguration(id: id)
             }
+        }
+    }
+
+    /// Returns true if the registry contains a model with the id. Otherwise, false.
+    public func contains(id: String) -> Bool {
+        lock.withLock {
+            registry[id] != nil
         }
     }
 

--- a/Libraries/MLXVLM/VLMModelFactory.swift
+++ b/Libraries/MLXVLM/VLMModelFactory.swift
@@ -159,19 +159,6 @@ public class VLMModelFactory: ModelFactory {
     /// registry of model id to configuration, e.g. `mlx-community/paligemma-3b-mix-448-8bit`
     public let modelRegistry: AbstractModelRegistry
 
-    /// Returns configuration from ``modelRegistry``.
-    ///
-    /// - Note: If the id doesn't exists in the configuration, this will return a new instance of it.
-    /// If you want to check if the configuration in model registry, you should use ``contains(id:)``.
-    public func configuration(id: String) -> ModelConfiguration {
-        modelRegistry.configuration(id: id)
-    }
-
-    /// Returns true if ``modelRegistry`` contains a model with the id. Otherwise, false.
-    public func contains(id: String) -> Bool {
-        modelRegistry.contains(id: id)
-    }
-
     public func _load(
         hub: HubApi, configuration: ModelConfiguration,
         progressHandler: @Sendable @escaping (Progress) -> Void

--- a/Libraries/MLXVLM/VLMModelFactory.swift
+++ b/Libraries/MLXVLM/VLMModelFactory.swift
@@ -159,8 +159,17 @@ public class VLMModelFactory: ModelFactory {
     /// registry of model id to configuration, e.g. `mlx-community/paligemma-3b-mix-448-8bit`
     public let modelRegistry: AbstractModelRegistry
 
+    /// Returns configuration from ``modelRegistry``.
+    ///
+    /// - Note: If the id doesn't exists in the configuration, this will return a new instance of it.
+    /// If you want to check if the configuration in model registry, you should use ``contains(id:)``.
     public func configuration(id: String) -> ModelConfiguration {
         modelRegistry.configuration(id: id)
+    }
+
+    /// Returns true if ``modelRegistry`` contains a model with the id. Otherwise, false.
+    public func contains(id: String) -> Bool {
+        modelRegistry.contains(id: id)
     }
 
     public func _load(


### PR DESCRIPTION
This PR adds contains(id:) method.

I added `var modelRegistry: AbstractModelRegistry { get }` to `ModelFactory` protocol to add default implementations for `configuration(id:)` and `contains(id:)` methods. This will reduce code duplications.