### PR TITLE
Add basic support for cancelling

### DIFF
--- a/Libraries/MLXLLM/LLMModel.swift
+++ b/Libraries/MLXLLM/LLMModel.swift
@@ -24,7 +24,7 @@ extension LLMModel {
         while y.tokens.size > prefillStepSize {
             let input = y[.newAxis, ..<prefillStepSize]
             let result = self(input, cache: cache.isEmpty ? nil : cache, state: state)
-            eval(cache)
+            try batchedEval(cache)
             y = y[prefillStepSize...]
         }
 

--- a/Libraries/MLXVLM/Models/Idefics3.swift
+++ b/Libraries/MLXVLM/Models/Idefics3.swift
@@ -811,6 +811,7 @@ public class Idefics3Processor: UserInputProcessor {
             // No image scenario
             let tokens = try tokenizer.encode(text: prompt)
             let tokensArray = MLXArray(tokens).expandedDimensions(axis: 0)
+            try Task.checkCancellation()
             let mask = ones(like: tokensArray)
             return LMInput(text: .init(tokens: tokensArray, mask: mask), image: nil)
         } else {
@@ -832,12 +833,17 @@ public class Idefics3Processor: UserInputProcessor {
 
             var image = try input.images[0].asCIImage()
             image = MediaProcessing.inSRGBToneCurveSpace(image)
+            
+            try Task.checkCancellation()
+            
             let targetSize = CGSize(
                 width: fixedImageSize,
                 height: fixedImageSize
             )
             image = MediaProcessing.apply(image, processing: input.processing)
+            try Task.checkCancellation()
             image = MediaProcessing.resampleBicubic(image, to: targetSize)
+            try Task.checkCancellation()
             image = MediaProcessing.normalize(
                 image,
                 mean: config.imageMeanTuple,
@@ -863,6 +869,7 @@ public class Idefics3Processor: UserInputProcessor {
             {
                 pixels = pixels.transposed(0, 2, 3, 1)
             }
+            try Task.checkCancellation()
 
             return LMInput(
                 text: .init(tokens: promptArray, mask: mask),

--- a/Libraries/MLXVLM/Models/Paligemma.swift
+++ b/Libraries/MLXVLM/Models/Paligemma.swift
@@ -485,12 +485,18 @@ public class PaligGemmaProcessor: UserInputProcessor {
         prompt =
             Array(repeating: "<image>", count: count).joined() + (tokenizer.bosToken ?? "") + prompt
             + "\n"
-
+        
+        try Task.checkCancellation()
+        
         let promptTokens = try tokenizer.encode(text: prompt)
         let promptArray = MLXArray(promptTokens).expandedDimensions(axis: 0)
+        
+        try Task.checkCancellation()
+        
         let mask = ones(like: promptArray).asType(.int8)
 
         let pixels = try prepare(image: input.images[0].asCIImage(), processing: input.processing)
+        try Task.checkCancellation()
 
         return LMInput(text: .init(tokens: promptArray, mask: mask), image: .init(pixels: pixels))
     }


### PR DESCRIPTION
Added `Task.checkCancellation()` to multiple places across `load`, `prepare` and `generate`.

Related issues:
https://github.com/ml-explore/mlx-swift-examples/issues/227
https://github.com/ml-explore/mlx-swift-examples/issues/230

