### PR TITLE
Make initializer and some methods public in GenerateResult and GenerateParameters

### DIFF
--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -79,7 +79,7 @@ public struct GenerateParameters: Sendable {
         self.repetitionContextSize = repetitionContextSize
     }
 
-    func sampler() -> LogitSampler {
+    public func sampler() -> LogitSampler {
         if temperature == 0 {
             return ArgMaxSampler()
         } else if topP > 0 && topP < 1 {
@@ -89,7 +89,7 @@ public struct GenerateParameters: Sendable {
         }
     }
 
-    func processor() -> LogitProcessor? {
+    public func processor() -> LogitProcessor? {
         if let repetitionPenalty, repetitionContextSize > 0 {
             return RepetitionContext(
                 repetitionPenalty: repetitionPenalty, repetitionContextSize: repetitionContextSize)
@@ -379,6 +379,23 @@ public struct TokenIterator: Sequence, IteratorProtocol {
 
 /// Result of a call to ``generate(input:parameters:context:didGenerate:)``.
 public struct GenerateResult: Sendable {
+    
+    /// Initializes a new `GenerateResult` instance.
+    ///
+    /// - Parameters:
+    ///   - inputText: The input text used for generation.
+    ///   - tokens: The array of tokens generated.
+    ///   - output: The generated output string.
+    ///   - promptTime: The time taken to prompt the input.
+    ///   - generateTime: The time taken to generate the output.
+    public init(inputText: LMInput.Text, tokens: [Int], output: String, promptTime: TimeInterval, generateTime: TimeInterval) {
+        self.inputText = inputText
+        self.tokens = tokens
+        self.output = output
+        self.promptTime = promptTime
+        self.generateTime = generateTime
+    }
+    
     /// input (prompt, images, etc.)
     public let inputText: LMInput.Text
 

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -379,7 +379,7 @@ public struct TokenIterator: Sequence, IteratorProtocol {
 
 /// Result of a call to ``generate(input:parameters:context:didGenerate:)``.
 public struct GenerateResult: Sendable {
-    
+
     /// Initializes a new `GenerateResult` instance.
     ///
     /// - Parameters:
@@ -388,14 +388,17 @@ public struct GenerateResult: Sendable {
     ///   - output: The generated output string.
     ///   - promptTime: The time taken to prompt the input.
     ///   - generateTime: The time taken to generate the output.
-    public init(inputText: LMInput.Text, tokens: [Int], output: String, promptTime: TimeInterval, generateTime: TimeInterval) {
+    public init(
+        inputText: LMInput.Text, tokens: [Int], output: String, promptTime: TimeInterval,
+        generateTime: TimeInterval
+    ) {
         self.inputText = inputText
         self.tokens = tokens
         self.output = output
         self.promptTime = promptTime
         self.generateTime = generateTime
     }
-    
+
     /// input (prompt, images, etc.)
     public let inputText: LMInput.Text
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -12,10 +12,10 @@
     {
       "identity" : "jinja",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/maiqingqiang/Jinja",
+      "location" : "https://github.com/johnmai-dev/Jinja",
       "state" : {
-        "revision" : "6dbe4c449469fb586d0f7339f900f0dd4d78b167",
-        "version" : "1.0.6"
+        "revision" : "bbddb92fc51ae420b87300298370fd1dfc308f73",
+        "version" : "1.1.1"
       }
     },
     {
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-argument-parser.git",
       "state" : {
-        "revision" : "41982a3656a71c768319979febd796c6fd111d5c",
-        "version" : "1.5.0"
+        "revision" : "0fbc8848e389af3bb55c182bc19ca9d5dc2f255b",
+        "version" : "1.4.0"
       }
     },
     {
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
-        "revision" : "94cf62b3ba8d4bed62680a282d4c25f9c63c2efb",
-        "version" : "1.1.0"
+        "revision" : "671108c96644956dddcd89dd59c203dcdb36cec7",
+        "version" : "1.1.4"
       }
     },
     {
@@ -68,8 +68,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/huggingface/swift-transformers",
       "state" : {
-        "revision" : "d42fdae473c49ea216671da8caae58e102d28709",
-        "version" : "0.1.14"
+        "revision" : "be855fac725dbae27264e47a3eb535cc422a4ba8",
+        "version" : "0.1.18"
       }
     }
   ],


### PR DESCRIPTION
## Summary
Changed the visibility of the `GenerateResult` initializer and several `GenerateParameters` methods to public to allow external access.

## Changes
- Updated the initializer in `GenerateResult` to public.
- Changed the following `GenerateParameters` methods to public:
  - `processor`
  - `sampler`

## Motivation
This change allows to create a custom `TokenIterator` and a custom `generate` function from other modules while keeping the return type `GenerateResult`.
