### PR TITLE
Update LLMEval and VLMEval using asyncStream

### DIFF
--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -780,7 +780,7 @@ public func generate(
 /// Represents metadata and statistics related to token generation.
 ///
 /// Provides information about the number of tokens processed during both the prompt and generation phases, as well as the time taken for each phase.
-public struct GenerateCompletionInfo {
+public struct GenerateCompletionInfo: Sendable {
     /// The number of tokens included in the input prompt.
     let promptTokenCount: Int
 


### PR DESCRIPTION
This draft PR updates the LLMEval and VLMEva example apps using the new asyncStream generate that was merged earlier today (#248 by @Alessan-git). Since asyncStream simplifies generating completions, I assume most developers will be more interested in learning how to use asyncStream than the previous method.

However, I ran into two issues I'm happy to fix.
- How can we cancel the asyncStream? In the example, this happens if maxTokens is reached
- I've reused the `try await modelContainer.perform { context in` closure from the original example. Is there a better way to access the modelContext actor? Right now, we still have to switch back to main actor in the `for await` loop, which seems unnecessary if not inconvenient in case you need to process the data on the original thread.

