### PR TITLE
Add quantization support to Qwen2 Model

### DIFF
--- a/Libraries/MLXLLM/Models/Qwen2.swift
+++ b/Libraries/MLXLLM/Models/Qwen2.swift
@@ -221,7 +221,7 @@ public struct Qwen2Configuration: Codable, Sendable {
     var ropeTraditional: Bool = false
     var ropeScaling: [String: StringOrNumber]? = nil
     var tieWordEmbeddings = false
-    var quantization: BaseConfiguration.Quantization?
+    public var quantization: BaseConfiguration.Quantization?
 
     enum CodingKeys: String, CodingKey {
         case hiddenSize = "hidden_size"

--- a/Libraries/MLXLLM/Models/Qwen2.swift
+++ b/Libraries/MLXLLM/Models/Qwen2.swift
@@ -221,6 +221,7 @@ public struct Qwen2Configuration: Codable, Sendable {
     var ropeTraditional: Bool = false
     var ropeScaling: [String: StringOrNumber]? = nil
     var tieWordEmbeddings = false
+    var quantization: BaseConfiguration.Quantization?
 
     enum CodingKeys: String, CodingKey {
         case hiddenSize = "hidden_size"
@@ -234,6 +235,7 @@ public struct Qwen2Configuration: Codable, Sendable {
         case ropeTraditional = "rope_traditional"
         case ropeScaling = "rope_scaling"
         case tieWordEmbeddings = "tie_word_embeddings"
+        case quantization = "quantization"
     }
 
     public init(from decoder: Decoder) throws {

--- a/Libraries/MLXLLM/Models/Qwen2.swift
+++ b/Libraries/MLXLLM/Models/Qwen2.swift
@@ -243,7 +243,8 @@ public struct Qwen2Configuration: Codable, Sendable {
         let container: KeyedDecodingContainer<Qwen2Configuration.CodingKeys> =
             try decoder.container(
                 keyedBy: Qwen2Configuration.CodingKeys.self)
-
+        self.quantization = try container.decodeIfPresent(
+            BaseConfiguration.Quantization.self, forKey: .quantization)
         self.hiddenSize = try container.decode(
             Int.self, forKey: Qwen2Configuration.CodingKeys.hiddenSize)
         self.hiddenLayers = try container.decode(


### PR DESCRIPTION
When attempting to load a quantized Deepcoder model I ran into issues due to mismatched parameter weight shape,
`❌ Error: Failed to load model weights: Mismatched parameter weight shape. Actual [152064, 640], expected [152064, 5120]'

This small enhancement adds quantisation decoding to the Qwen2 model config allowing us to pass in the quantisation to the loadWeights function.

Example loading code below:

```swift
 fileprivate func loadModel(_ modelURL: URL) throws {
        if self.model == nil {
            
            // Path to Config file
            let configURL = modelURL.appendingPathComponent("config.json")

            // Load config json as data
            let configData: Data
            do {
                configData = try Data(contentsOf: configURL)
            } catch {
                throw LoadingError.configLoadFailed(error)
            }

            // Decode the config
            let config: Qwen2Configuration
            do {
                config = try JSONDecoder().decode(Qwen2Configuration.self, from: configData)
            } catch {
                throw LoadingError.configLoadFailed(error)
            }

            // Load the model with quantization metadata from config
            let loadedModel = Qwen2Model(config)
            do {
                try MLXLMCommon.loadWeights(modelDirectory: modelURL, model: loadedModel, quantization: config.quantization)   //  <--- Function called with the config quantisation metadata
                logQuantizedModules(loadedModel)          //  <--- Add this testing and debugging
            } catch {
                throw LoadingError.weightLoadFailed(error)
            }

            self.model = loadedModel
        }
    }
    
    ...
    
 fileprivate func logQuantizedModules(_ model: Module) {
        for (path, module) in model.leafModules().flattened() {
            if module is QuantizedLinear {
                print("✅ QuantizedLinear at: \(path)")
            } else if module is QuantizedEmbedding {
                print("✅ QuantizedEmbedding at: \(path)")
            }
        }
    }
```

Steps to test:
1. Download a quantized model (such as https://huggingface.co/mlx-community/DeepCoder-1.5B-Preview-4bit).
2. Load the model using code similar to the example above.
3. Check the model loads successfully and no error is thrown.
4. Optionally use the logging utility function above to verify it prints out the 