### PR TITLE
Update MLXChatExample for iOS Sandboxing

### DIFF
--- a/Applications/MLXChatExample/Services/MLXService.swift
+++ b/Applications/MLXChatExample/Services/MLXService.swift
@@ -58,7 +58,7 @@ class MLXService {
 
             // Load model and track download progress
             let container = try await factory.loadContainer(
-                hub: .default, configuration: model.configuration
+                configuration: model.configuration
             ) { progress in
                 Task { @MainActor in
                     self.modelDownloadProgress = progress

--- a/Applications/MLXChatExample/Services/MLXService.swift
+++ b/Applications/MLXChatExample/Services/MLXService.swift
@@ -58,7 +58,7 @@ class MLXService {
 
             // Load model and track download progress
             let container = try await factory.loadContainer(
-                configuration: model.configuration
+                hub: .default, configuration: model.configuration
             ) { progress in
                 Task { @MainActor in
                     self.modelDownloadProgress = progress

--- a/Applications/MLXChatExample/Support/HubApi+default.swift
+++ b/Applications/MLXChatExample/Support/HubApi+default.swift
@@ -12,10 +12,13 @@ import Foundation
 extension HubApi {
     /// Default HubApi instance configured to download models to the user's Downloads directory
     /// under a 'huggingface' subdirectory.
-#if(os(macOS))
+#if os(macOS)
     static let `default` = HubApi(
-        downloadBase: URL.downloadsDirectory.appending(path: "huggingface"))
+        downloadBase: URL.downloadsDirectory.appending(path: "huggingface")
+    )
 #else
-    static let `default` = HubApi()
+    static let `default` = HubApi(
+        downloadBase: URL.cachesDirectory.appending(path: "huggingface")
+    )
 #endif
 }

--- a/Applications/MLXChatExample/Support/HubApi+default.swift
+++ b/Applications/MLXChatExample/Support/HubApi+default.swift
@@ -12,6 +12,10 @@ import Foundation
 extension HubApi {
     /// Default HubApi instance configured to download models to the user's Downloads directory
     /// under a 'huggingface' subdirectory.
+#if(os(macOS))
     static let `default` = HubApi(
         downloadBase: URL.downloadsDirectory.appending(path: "huggingface"))
+#else
+    static let `default` = HubApi()
+#endif
 }

--- a/MLXChatExample.entitlements
+++ b/MLXChatExample.entitlements
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.kernel.increased-memory-limit</key>
+	<true/>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.files.downloads.read-write</key>
+	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
+</dict>
+</plist>

--- a/mlx-swift-examples.xcodeproj/project.pbxproj
+++ b/mlx-swift-examples.xcodeproj/project.pbxproj
@@ -190,6 +190,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		0A7C100B2DC37CEA00FD5155 /* MLXChatExample.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = MLXChatExample.entitlements; sourceTree = "<group>"; };
 		0AC74EBB2D136221003C90A7 /* VLMEval.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = VLMEval.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		0AC74EC92D13622A003C90A7 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		0AC74ECB2D13622A003C90A7 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -522,6 +523,7 @@
 		C39273672B60697700368D5D = {
 			isa = PBXGroup;
 			children = (
+				0A7C100B2DC37CEA00FD5155 /* MLXChatExample.entitlements */,
 				C325DE3F2B648CDB00628871 /* README.md */,
 				F8D7023A2BB4E223003D7CF5 /* Package.swift */,
 				C3C36A6C2CA714600099FFA4 /* Configuration */,
@@ -1311,6 +1313,7 @@
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_ENTITLEMENTS = MLXChatExample.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 1;
@@ -1376,6 +1379,7 @@
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_ENTITLEMENTS = MLXChatExample.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 1;


### PR DESCRIPTION
On iOS, due to sandboxing, using the `default` hub gives an error along the line because it cannot store in the downloads directory: 

```
You do not have permission to save the file "model-name" in the folder "mlx-community"
```

We can directly use the default parameter of `HubApi()` that stores under the documents directory, accessible on both iOS and macOS. 

Also, I wonder the need for the `default` static value then? 

```swift
/// Extension providing a default HubApi instance for downloading model files
extension HubApi {
    /// Default HubApi instance configured to download models to the user's Downloads directory
    /// under a 'huggingface' subdirectory.
    static let `default` = HubApi(
        downloadBase: URL.downloadsDirectory.appending(path: "huggingface"))
}
```

Thank you creating this example @ibrahimcetin! 
