### PR TITLE
refactor: Improve model loading with structured progress tracking

### DIFF
--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -55,7 +55,7 @@ public protocol LogitProcessor: Sendable {
 public struct GenerateParameters: Sendable {
 
     /// Step size for processing the prompt
-    public var prefillStepSize = 512
+    public var prefillStepSize: Int
 
     /// Maximum tokens to generate
     public var maxTokens: Int?
@@ -74,14 +74,18 @@ public struct GenerateParameters: Sendable {
 
     public init(
         maxTokens: Int? = nil,
-        temperature: Float = 0.6, topP: Float = 1.0, repetitionPenalty: Float? = nil,
-        repetitionContextSize: Int = 20
+        temperature: Float = 0.6,
+        topP: Float = 1.0,
+        repetitionPenalty: Float? = nil,
+        repetitionContextSize: Int = 20,
+        prefillStepSize: Int = 512
     ) {
         self.maxTokens = maxTokens
         self.temperature = temperature
         self.topP = topP
         self.repetitionPenalty = repetitionPenalty
         self.repetitionContextSize = repetitionContextSize
+        self.prefillStepSize = prefillStepSize
     }
 
     public func sampler() -> LogitSampler {

--- a/Libraries/StableDiffusion/StableDiffusion.swift
+++ b/Libraries/StableDiffusion/StableDiffusion.swift
@@ -141,9 +141,11 @@ public actor ModelContainer<M> {
 
     /// create a ``ModelContainer`` that supports ``TextToImageGenerator``
     static public func createTextToImageGenerator(
-        configuration: StableDiffusionConfiguration, loadConfiguration: LoadConfiguration = .init()
+        configuration: StableDiffusionConfiguration,
+        hub: HubApi = HubApi(),
+        loadConfiguration: LoadConfiguration = .init()
     ) throws -> ModelContainer<TextToImageGenerator> {
-        if let model = try configuration.textToImageGenerator(configuration: loadConfiguration) {
+        if let model = try configuration.textToImageGenerator(hub: hub, configuration: loadConfiguration) {
             return .init(model: model)
         } else {
             throw ModelContainerError.unableToCreate(configuration.id, "TextToImageGenerator")


### PR DESCRIPTION
## Small improvement on progress tracking for model loading operations

Added structured progress tracking across our model factories with defined percentage ranges for each loading stage. This gives users clearer feedback during initialization.

## Changes

- Added percentage-based progress tracking (download 0-30%, config 30-50/60%, weights 50/60-80%, tokenizer 80-100%)
- Fixed hub API reference in StableDiffusion model container
- Added support for loading SD models from custom local directories
- Standardized parameter handling in GenerateParameters

The progress indicators now show meaningful percentages instead of jumping unpredictably, which helps users understand what's happening during longer loading operations. 