### PR TITLE
Fix UserInput init(messages:images:videos:tools:additionalContext:) broken for VLM

### DIFF
--- a/Libraries/MLXLMCommon/UserInput.swift
+++ b/Libraries/MLXLMCommon/UserInput.swift
@@ -227,6 +227,8 @@ public struct UserInput: Sendable {
         additionalContext: [String: Any]? = nil
     ) {
         self.prompt = .messages(messages)
+        self.images = images
+        self.videos = videos
         self.tools = tools
         self.additionalContext = additionalContext
     }


### PR DESCRIPTION
Fix `UserInput` `init(messages:images:videos:tools:additionalContext:)` not setting the images and videos arrays resulting in VLM not able to analyze images or videos when using this init.
The bug was introduced in (#257)