### PR TITLE
swift-format

### DIFF
--- a/Applications/MLXChatExample/Support/HubApi+default.swift
+++ b/Applications/MLXChatExample/Support/HubApi+default.swift
@@ -12,13 +12,13 @@ import Foundation
 extension HubApi {
     /// Default HubApi instance configured to download models to the user's Downloads directory
     /// under a 'huggingface' subdirectory.
-#if os(macOS)
-    static let `default` = HubApi(
-        downloadBase: URL.downloadsDirectory.appending(path: "huggingface")
-    )
-#else
-    static let `default` = HubApi(
-        downloadBase: URL.cachesDirectory.appending(path: "huggingface")
-    )
-#endif
+    #if os(macOS)
+        static let `default` = HubApi(
+            downloadBase: URL.downloadsDirectory.appending(path: "huggingface")
+        )
+    #else
+        static let `default` = HubApi(
+            downloadBase: URL.cachesDirectory.appending(path: "huggingface")
+        )
+    #endif
 }


### PR DESCRIPTION
another case where swift-format / CI was missed -- I know it ran, I can see the failure:

https://app.circleci.com/pipelines/github/ml-explore/mlx-swift-examples/726/workflows/a30af41a-86b8-4738-9b6d-c5372faabecd/jobs/1233

but I am not sure how I was able to merge it with the failure.