### PR TITLE
Fix #297 - Basic markdown support in MLXChatExample

### DIFF
--- a/Applications/MLXChatExample/README.md
+++ b/Applications/MLXChatExample/README.md
@@ -73,6 +73,28 @@ The codebase is thoroughly documented with:
 - Clear inline comments explaining complex logic
 - DocC documentation format
 
+### Markdown Support
+
+This sample app renders markdown content using SwiftUI's native `Text` view by passing the content as a `LocalizedStringKey`:
+
+```swift
+Text(LocalizedStringKey(message.content))
+```
+
+#### Limitations and Alternatives
+
+The default SwiftUI markdown rendering only supports standard markdown syntax. It does not support advanced features like tables and task lists that are available in GitHub Flavored Markdown (GFM).
+
+For more comprehensive markdown support:
+
+- **GitHub Flavored Markdown**: Consider using the [swift-markdown-ui](https://github.com/gonzalezreal/swift-markdown-ui) library. However, be aware that this library currently has an [unresolved issue with text selection](https://github.com/gonzalezreal/swift-markdown-ui/issues/264), which is why it wasn't used in this example.
+
+- **Enhanced Text Selection**: If you're satisfied with standard markdown but want better text selection capabilities on iOS (instead of only being able to select and copy entire content block), consider combining:
+  - [SelectableText](https://github.com/kevinhermawan/SelectableText) for improved selection functionality
+  - [MarkdownToAttributedString](https://github.com/madebywindmill/MarkdownToAttributedString) for markdown formatting
+
+> More discussion on this can be found on [issue #297](https://github.com/ml-explore/mlx-swift-examples/issues/297)
+
 ## Getting Started
 
 1. Clone the repository

--- a/Applications/MLXChatExample/Views/MessageView.swift
+++ b/Applications/MLXChatExample/Views/MessageView.swift
@@ -47,8 +47,9 @@ struct MessageView: View {
                             .clipShape(.rect(cornerRadius: 12))
                     }
 
-                    // Message content with tinted background
-                    Text(message.content)
+                    // Message content with tinted background.
+                    // LocalizedStringKey used to trigger default handling of markdown content.
+                    Text(LocalizedStringKey(message.content))
                         .padding(.vertical, 8)
                         .padding(.horizontal, 12)
                         .background(.tint, in: .rect(cornerRadius: 16))
@@ -58,8 +59,9 @@ struct MessageView: View {
 
         case .assistant:
             // Assistant messages are left-aligned without background
+            // LocalizedStringKey used to trigger default handling of markdown content.
             HStack {
-                Text(message.content)
+                Text(LocalizedStringKey(message.content))
                     .textSelection(.enabled)
 
                 Spacer()


### PR DESCRIPTION
PR as a suggestion for #297, as I've been doing something similar in my app.

If you just want simple markdown (i.e not the Github flavour) the SwiftUI text view supports this out of the box if you pass in the content as a LocalizedStringKey.

This might not fit everyone's needs, but for the way you are using it in this sample app, it looks fine.

![image](https://github.com/user-attachments/assets/55db5eb4-9af8-4b25-a278-5722590f4ed1)

One drawback to this (and using the SwiftUI "Text" view in general) is that you don't get to select individual characters/words on iOS or iPadOS (Just all of the content within that view in one go). If you want that, it might be worth looking at something like SelectableText (https://github.com/kevinhermawan/SelectableText) mixed with formatting the content beforehand with something like MarkdownToAttributedString (https://github.com/madebywindmill/MarkdownToAttributedString)

Anyway, I feel like for this use case, what is proposed in this PR is simple and should work. If you want it formatted differently or you want me to change the data type of "message.content" so it is not set in the views, im happy to make these changes.  

Thanks,
Kawba