### PR TITLE
Convert GenerateParameters to a protocol

### DIFF
--- a/Applications/LLMEval/ContentView.swift
+++ b/Applications/LLMEval/ContentView.swift
@@ -176,7 +176,7 @@ class LLMEvaluator {
     let modelConfiguration = LLMRegistry.qwen3_1_7b_4bit
 
     /// parameters controlling the output
-    let generateParameters = GenerateParameters(maxTokens: 240, temperature: 0.6)
+    let generateParameters = DefaultGenerateParameters(maxTokens: 240, temperature: 0.6)
     let updateInterval = Duration.seconds(0.25)
 
     /// A task responsible for handling the generation process.

--- a/Applications/LoRATrainingExample/ContentView.swift
+++ b/Applications/LoRATrainingExample/ContentView.swift
@@ -130,7 +130,7 @@ class LoRAEvaluator {
     private let learningRate: Float = 1e-5
     private let parameters = LoRATrain.Parameters(batchSize: 1, iterations: 200)
 
-    private let generateParameters = GenerateParameters(temperature: 0.6, topP: 0.9)
+    private let generateParameters = DefaultGenerateParameters(temperature: 0.6, topP: 0.9)
     private let evaluateShowEvery = 8
     private let maxTokens = 200
 

--- a/Applications/MLXChatExample/Services/MLXService.swift
+++ b/Applications/MLXChatExample/Services/MLXService.swift
@@ -113,7 +113,7 @@ class MLXService {
         return try await modelContainer.perform { (context: ModelContext) in
             let lmInput = try await context.processor.prepare(input: userInput)
             // Set temperature for response randomness (0.7 provides good balance)
-            let parameters = GenerateParameters(temperature: 0.7)
+            let parameters = DefaultGenerateParameters(temperature: 0.7)
 
             return try MLXLMCommon.generate(
                 input: lmInput, parameters: parameters, context: context)

--- a/Applications/VLMEval/ContentView.swift
+++ b/Applications/VLMEval/ContentView.swift
@@ -339,7 +339,7 @@ class VLMEvaluator {
     let modelConfiguration = VLMRegistry.smolvlm
 
     /// parameters controlling the output – use values appropriate for the model selected above
-    let generateParameters = MLXLMCommon.GenerateParameters(
+    let generateParameters = MLXLMCommon.DefaultGenerateParameters(
         maxTokens: 800, temperature: 0.7, topP: 0.9)
     let updateInterval = Duration.seconds(0.25)
 

--- a/Libraries/MLXLMCommon/Documentation.docc/porting.md
+++ b/Libraries/MLXLMCommon/Documentation.docc/porting.md
@@ -518,7 +518,7 @@ let modelConfiguration = ModelConfiguration(id: "mlx-community/quantized-gemma-2
 let container = try await MLXModelFactory.shared.loadContainer(configuration: modelConfiguration)
 
 // prepare the prompt and parameters used to generate the response
-let generateParameters = GenerateParameters()
+let generateParameters = DefaultGenerateParameters()
 let input = UserInput(prompt: "Are cherries sweet?")
 
 // run inference

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -52,21 +52,39 @@ public protocol LogitProcessor: Sendable {
 /// - ``LogitProcessor``
 ///
 /// for the `TokenIterator`.
-public struct GenerateParameters: Sendable {
-
+public protocol GenerateParameters: Sendable {
     /// Step size for processing the prompt
-    public var prefillStepSize = 512
+    var prefillStepSize: Int { get }
 
     /// Maximum tokens to generate
-    public var maxTokens: Int?
+    var maxTokens: Int? { get }
 
     /// sampling temperature
-    public var temperature: Float = 0.6
+    var temperature: Float { get }
 
     /// top p sampling
-    public var topP: Float = 1.0
+    var topP: Float { get }
 
     /// penalty factor for repeating tokens
+    var repetitionPenalty: Float? { get }
+
+    var repetitionContextSize: Int { get }
+
+    func sampler() -> LogitSampler
+
+    func processor() -> LogitProcessor?
+}
+
+public struct DefaultGenerateParameters: GenerateParameters {
+
+    public var prefillStepSize = 512
+
+    public var maxTokens: Int?
+
+    public var temperature: Float = 0.6
+
+    public var topP: Float = 1.0
+
     public var repetitionPenalty: Float?
 
     /// number of tokens to consider for repetition penalty

--- a/Tools/llm-tool/LLMTool.swift
+++ b/Tools/llm-tool/LLMTool.swift
@@ -136,7 +136,7 @@ struct GenerateArguments: ParsableArguments, Sendable {
     var quiet = false
 
     var generateParameters: GenerateParameters {
-        GenerateParameters(
+        DefaultGenerateParameters(
             maxTokens: maxTokens,
             temperature: temperature, topP: topP, repetitionPenalty: repetitionPenalty,
             repetitionContextSize: repetitionContextSize)


### PR DESCRIPTION
To allow customization of the `LogitSampler` and `LogitProcessor` behavior, this PR converts `GenerateParameters` from a struct to a protocol.

The motivation would be to more easily allow for some work on grammar-constrained output generation, as mentioned in https://github.com/ml-explore/mlx-swift-examples/issues/221#issuecomment-2910291469 

If merged, this PR is a breaking change for library consumers if they instantiate a `GenerateParameters` object in their own code. So while not as clean, this could be modified to preserve the `GenerateParameters` name and choose a new name for the protocol instead.

An alternative approach to doing this could be to allow setting override values for the sampler and processor that bypass the logic in the functions in this existing structure for picking these objects.