### PR TITLE
Fix Mutability Build Errors

### DIFF
--- a/Libraries/Embedders/Bert.swift
+++ b/Libraries/Embedders/Bert.swift
@@ -41,7 +41,7 @@ private class BertEmbedding: Module {
         tokenTypeIds: MLXArray? = nil
     ) -> MLXArray {
         let posIds = positionIds ?? broadcast(MLXArray.arange(inputIds.dim(1)), to: inputIds.shape)
-        let words = wordEmbeddings(inputIds) + positionEmbeddings(posIds)
+        var words = wordEmbeddings(inputIds) + positionEmbeddings(posIds)
         if let tokenTypeIds, let tokenTypeEmbeddings {
             words += tokenTypeEmbeddings(tokenTypeIds)
         }

--- a/Libraries/Embedders/NomicBert.swift
+++ b/Libraries/Embedders/NomicBert.swift
@@ -35,7 +35,7 @@ class NomicEmbedding: Module {
         _ inputIds: MLXArray, positionIds: MLXArray? = nil,
         tokenTypeIds: MLXArray? = nil
     ) -> MLXArray {
-        let words = wordEmbeddings(inputIds)
+        var words = wordEmbeddings(inputIds)
 
         if let tokenTypeIds, let tokenTypeEmbeddings {
             words += tokenTypeEmbeddings(tokenTypeIds)


### PR DESCRIPTION
The Embedders Package doesn't build due to the two let / var mutability errors. Changed 'let words' to 'var words'.