### PR TITLE
Fix LFM2

### DIFF
--- a/Libraries/MLXLLM/Models/LFM2.swift
+++ b/Libraries/MLXLLM/Models/LFM2.swift
@@ -11,76 +11,45 @@ import MLXLMCommon
 import MLXNN
 
 public struct LFM2Configuration: Codable, Sendable {
-    var modelType: String = "lfm2"
-    var headDim: Int?
-    var blockFFDim: Int?
-    var vocabularySize: Int = 65536
-    var hiddenSize: Int
-    var intermediateSize: Int?
-    var hiddenLayers: Int
-    var attentionHeads: Int
-    var kvHeads: Int
-    var maxPositionEmbeddings: Int?
-    var normEps: Float
-    var padTokenId: Int?
-    var bosTokenId: Int = 1
-    var eosTokenId: Int = 2
-    var tieWordEmbeddings: Bool = true
-    var convBias: Bool = false
-    var convLCache: Int = 3
-    var blockMultipleOf: Int = 256
-    var blockFFNDimMultiplier: Float = 1.0
-    var blockAutoAdjustFFDim: Bool = true
-    var fullAttnIdxs: [Int]?
-    var layerTypes: [String]?
-    var ropeTraditional: Bool = false
-    var ropeScaling: [String: StringOrNumber]?
-    var ropeTheta: Float = 1000000.0
-
-    var resolvedIntermediateSize: Int {
-        blockFFDim ?? intermediateSize ?? hiddenSize
-    }
-
-    var resolvedHeadDim: Int {
-        headDim ?? (hiddenSize / attentionHeads)
-    }
-
-    var resolvedLayerTypes: [String] {
-        if let layerTypes {
-            return layerTypes
-        }
-
-        let fullAttnIdxs = fullAttnIdxs ?? Array(0 ..< hiddenLayers)
-        return (0 ..< hiddenLayers).map { i in
-            fullAttnIdxs.contains(i) ? "full_attention" : "conv"
-        }
-    }
+    let modelType: String
+    let vocabularySize: Int
+    let hiddenSize: Int
+    let hiddenLayers: Int
+    let attentionHeads: Int
+    let kvHeads: Int
+    let maxPositionEmbeddings: Int?
+    let normEps: Float
+    let convBias: Bool
+    let convLCache: Int
+    private let _blockDim: Int?
+    var blockDim: Int { _blockDim ?? hiddenSize }
+    private let _blockFFDim: Int?
+    var blockFFDim: Int { _blockFFDim ?? hiddenSize }
+    let blockMultipleOf: Int
+    let blockFFNDimMultiplier: Float
+    let blockAutoAdjustFFDim: Bool
+    private let _fullAttnIdxs: [Int]?
+    var fullAttnIdxs: [Int] { _fullAttnIdxs ?? Array(0 ..< hiddenLayers) }
+    let ropeTheta: Float
+    var headDimensions: Int { hiddenSize / attentionHeads }
 
     enum CodingKeys: String, CodingKey {
         case modelType = "model_type"
-        case headDim = "head_dim"
-        case blockFFDim = "block_ff_dim"
         case vocabularySize = "vocab_size"
         case hiddenSize = "hidden_size"
-        case intermediateSize = "intermediate_size"
         case hiddenLayers = "num_hidden_layers"
         case attentionHeads = "num_attention_heads"
         case kvHeads = "num_key_value_heads"
         case maxPositionEmbeddings = "max_position_embeddings"
         case normEps = "norm_eps"
-        case padTokenId = "pad_token_id"
-        case bosTokenId = "bos_token_id"
-        case eosTokenId = "eos_token_id"
-        case tieWordEmbeddings = "tie_word_embeddings"
         case convBias = "conv_bias"
         case convLCache = "conv_L_cache"
+        case _blockDim = "block_dim"
+        case _blockFFDim = "block_ff_dim"
         case blockMultipleOf = "block_multiple_of"
         case blockFFNDimMultiplier = "block_ffn_dim_multiplier"
         case blockAutoAdjustFFDim = "block_auto_adjust_ff_dim"
-        case fullAttnIdxs = "full_attn_idxs"
-        case layerTypes = "layer_types"
-        case ropeTraditional = "rope_traditional"
-        case ropeScaling = "rope_scaling"
+        case _fullAttnIdxs = "full_attn_idxs"
         case ropeTheta = "rope_theta"
     }
 
@@ -88,37 +57,26 @@ public struct LFM2Configuration: Codable, Sendable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
         self.modelType = try container.decodeIfPresent(String.self, forKey: .modelType) ?? "lfm2"
-        self.headDim = try container.decodeIfPresent(Int.self, forKey: .headDim)
-        self.blockFFDim = try container.decodeIfPresent(Int.self, forKey: .blockFFDim)
         self.vocabularySize =
             try container.decodeIfPresent(Int.self, forKey: .vocabularySize) ?? 65536
         self.hiddenSize = try container.decode(Int.self, forKey: .hiddenSize)
-        self.intermediateSize = try container.decodeIfPresent(Int.self, forKey: .intermediateSize)
         self.hiddenLayers = try container.decode(Int.self, forKey: .hiddenLayers)
         self.attentionHeads = try container.decode(Int.self, forKey: .attentionHeads)
         self.kvHeads = try container.decode(Int.self, forKey: .kvHeads)
         self.maxPositionEmbeddings = try container.decodeIfPresent(
             Int.self, forKey: .maxPositionEmbeddings)
         self.normEps = try container.decode(Float.self, forKey: .normEps)
-        self.padTokenId = try container.decodeIfPresent(Int.self, forKey: .padTokenId)
-        self.bosTokenId = try container.decodeIfPresent(Int.self, forKey: .bosTokenId) ?? 1
-        self.eosTokenId = try container.decodeIfPresent(Int.self, forKey: .eosTokenId) ?? 2
-        self.tieWordEmbeddings =
-            try container.decodeIfPresent(Bool.self, forKey: .tieWordEmbeddings) ?? true
         self.convBias = try container.decodeIfPresent(Bool.self, forKey: .convBias) ?? false
         self.convLCache = try container.decodeIfPresent(Int.self, forKey: .convLCache) ?? 3
+        self._blockDim = try container.decodeIfPresent(Int.self, forKey: ._blockDim)
+        self._blockFFDim = try container.decodeIfPresent(Int.self, forKey: ._blockFFDim)
         self.blockMultipleOf =
             try container.decodeIfPresent(Int.self, forKey: .blockMultipleOf) ?? 256
         self.blockFFNDimMultiplier =
             try container.decodeIfPresent(Float.self, forKey: .blockFFNDimMultiplier) ?? 1.0
         self.blockAutoAdjustFFDim =
             try container.decodeIfPresent(Bool.self, forKey: .blockAutoAdjustFFDim) ?? true
-        self.fullAttnIdxs = try container.decodeIfPresent([Int].self, forKey: .fullAttnIdxs)
-        self.layerTypes = try container.decodeIfPresent([String].self, forKey: .layerTypes)
-        self.ropeTraditional =
-            try container.decodeIfPresent(Bool.self, forKey: .ropeTraditional) ?? false
-        self.ropeScaling = try container.decodeIfPresent(
-            [String: StringOrNumber].self, forKey: .ropeScaling)
+        self._fullAttnIdxs = try container.decodeIfPresent([Int].self, forKey: ._fullAttnIdxs)
         self.ropeTheta = try container.decodeIfPresent(Float.self, forKey: .ropeTheta) ?? 1000000.0
     }
 }
@@ -144,7 +102,7 @@ private class Attention: Module {
         let dim = args.hiddenSize
         let heads = args.attentionHeads
         let kvHeads = args.kvHeads
-        self.headDim = args.resolvedHeadDim
+        self.headDim = args.headDimensions
 
         self.scale = pow(Float(headDim), -0.5)
 
@@ -156,24 +114,10 @@ private class Attention: Module {
         _qLayerNorm.wrappedValue = RMSNorm(dimensions: headDim, eps: args.normEps)
         _kLayerNorm.wrappedValue = RMSNorm(dimensions: headDim, eps: args.normEps)
 
-        let ropeScale: Float
-        if let ropeScaling = args.ropeScaling, ropeScaling["type"] == .string("linear"),
-            let factor = ropeScaling["factor"]
-        {
-            if let v = factor.asFloat() {
-                ropeScale = 1 / v
-            } else {
-                fatalError("ropeScaling.factor must be a float")
-            }
-        } else {
-            ropeScale = 1
-        }
-
         self.rope = RoPE(
             dimensions: headDim,
-            traditional: args.ropeTraditional,
-            base: args.ropeTheta,
-            scale: ropeScale
+            traditional: false,
+            base: args.ropeTheta
         )
     }
 
@@ -213,7 +157,7 @@ private class Attention: Module {
     }
 }
 
-private class LFM2ShortConv: Module {
+private class ShortConv: Module {
     let args: LFM2Configuration
     let layerIdx: Int
     let lCache: Int
@@ -233,7 +177,6 @@ private class LFM2ShortConv: Module {
             inputChannels: args.hiddenSize,
             outputChannels: args.hiddenSize,
             kernelSize: lCache,
-            padding: lCache - 1,
             groups: args.hiddenSize,
             bias: bias
         )
@@ -243,37 +186,28 @@ private class LFM2ShortConv: Module {
     }
 
     public func callAsFunction(_ x: MLXArray, cache: MambaCache?) -> MLXArray {
-        let seqlen = x.dim(1)
-        let bcx = inProj(x)
-        let bcxSplit = bcx.split(parts: 3, axis: -1)
-        let b = bcxSplit[0]
-        let c = bcxSplit[1]
-        let x_proj = bcxSplit[2]
-        let bx = b * x_proj
+        let BCx = inProj(x)
+        let BCxSplit = BCx.split(parts: 3, axis: -1)
+        let B = BCxSplit[0]
+        let C = BCxSplit[1]
+        let x = BCxSplit[2]
+        var Bx = B * x
 
-        var convOut: MLXArray
-
-        if let cache, x.dim(1) == 1 {
-            var convState = cache[0] ?? MLXArray.zeros([bx.dim(0), lCache, args.hiddenSize])
-
-            convState = roll(convState, shift: -2, axis: -2)
-            convState[0..., -1, 0...] = bx[0..., 0, 0...]
-            cache[0] = convState
-
-            convOut = (convState.transposed(0, 2, 1) * conv.weight[0..., 0..., 0]).sum(
-                axis: -1, keepDims: true)
-            if bias {
-                convOut = convOut + conv.bias!.expandedDimensions(axes: [-1])
-            }
-            convOut = convOut.reshaped(bx.dim(0), 1, -1)
-        } else {
-            if let cache {
-                cache[0] = bx[0..., (-lCache)..., 0...]
-            }
-            convOut = conv(bx)[0..., ..<seqlen, 0...]
+        var state: MLXArray? = nil
+        if let cache {
+            state = cache[0]
+        }
+        if state == nil {
+            state = MLXArray.zeros([Bx.dim(0), lCache - 1, args.hiddenSize], dtype: Bx.dtype)
         }
 
-        let y = c * convOut
+        Bx = concatenated([state!, Bx], axis: -2)
+        if let cache {
+            cache[0] = Bx[0..., (Bx.dim(1) - (lCache - 1))..., 0...]
+        }
+
+        let convOut = conv(Bx)
+        let y = C * convOut
         return outProj(y)
     }
 }
@@ -283,20 +217,26 @@ private class MLP: Module, UnaryLayer {
     @ModuleInfo(key: "w2") var w2: Linear
     @ModuleInfo(key: "w3") var w3: Linear
 
-    public init(_ args: LFM2Configuration) {
-        var intermediateSize = args.resolvedIntermediateSize
+    public init(
+        dim: Int,
+        ffDim: Int,
+        multipleOf: Int,
+        autoAdjustFFDim: Bool,
+        ffnDimMultiplier: Float?
+    ) {
+        var adjustedFFDim = ffDim
 
-        if args.blockAutoAdjustFFDim {
-            intermediateSize = Int(Float(2 * intermediateSize) / 3.0)
-            intermediateSize = Int(args.blockFFNDimMultiplier * Float(intermediateSize))
-            intermediateSize =
-                args.blockMultipleOf
-                * ((intermediateSize + args.blockMultipleOf - 1) / args.blockMultipleOf)
+        if autoAdjustFFDim {
+            adjustedFFDim = Int(Float(2 * ffDim) / 3.0)
+            if let multiplier = ffnDimMultiplier {
+                adjustedFFDim = Int(multiplier * Float(adjustedFFDim))
+            }
+            adjustedFFDim = multipleOf * ((adjustedFFDim + multipleOf - 1) / multipleOf)
         }
 
-        _w1.wrappedValue = Linear(args.hiddenSize, intermediateSize, bias: false)
-        _w2.wrappedValue = Linear(intermediateSize, args.hiddenSize, bias: false)
-        _w3.wrappedValue = Linear(args.hiddenSize, intermediateSize, bias: false)
+        _w1.wrappedValue = Linear(dim, adjustedFFDim, bias: false)
+        _w2.wrappedValue = Linear(adjustedFFDim, dim, bias: false)
+        _w3.wrappedValue = Linear(dim, adjustedFFDim, bias: false)
     }
 
     public func callAsFunction(_ x: MLXArray) -> MLXArray {
@@ -308,21 +248,27 @@ private class DecoderLayer: Module {
     let isAttentionLayer: Bool
 
     @ModuleInfo(key: "self_attn") var attention: Attention?
-    @ModuleInfo(key: "conv") var conv: LFM2ShortConv?
+    @ModuleInfo(key: "conv") var conv: ShortConv?
     @ModuleInfo(key: "feed_forward") var feedForward: MLP
     @ModuleInfo(key: "operator_norm") var operatorNorm: RMSNorm
     @ModuleInfo(key: "ffn_norm") var ffnNorm: RMSNorm
 
     public init(_ args: LFM2Configuration, layerIdx: Int) {
-        self.isAttentionLayer = args.resolvedLayerTypes[layerIdx] == "full_attention"
+        self.isAttentionLayer = args.fullAttnIdxs.contains(layerIdx)
 
         if isAttentionLayer {
             _attention.wrappedValue = Attention(args)
         } else {
-            _conv.wrappedValue = LFM2ShortConv(args, layerIdx: layerIdx)
+            _conv.wrappedValue = ShortConv(args, layerIdx: layerIdx)
         }
 
-        _feedForward.wrappedValue = MLP(args)
+        _feedForward.wrappedValue = MLP(
+            dim: args.blockDim,
+            ffDim: args.blockFFDim,
+            multipleOf: args.blockMultipleOf,
+            autoAdjustFFDim: args.blockAutoAdjustFFDim,
+            ffnDimMultiplier: args.blockFFNDimMultiplier
+        )
         _operatorNorm.wrappedValue = RMSNorm(dimensions: args.hiddenSize, eps: args.normEps)
         _ffnNorm.wrappedValue = RMSNorm(dimensions: args.hiddenSize, eps: args.normEps)
     }
@@ -330,19 +276,15 @@ private class DecoderLayer: Module {
     public func callAsFunction(
         _ x: MLXArray, mask: MLXFast.ScaledDotProductAttentionMaskMode, cache: KVCache?
     ) -> MLXArray {
-        let residual = x
-        var x = x
-
+        let r: MLXArray
         if isAttentionLayer {
-            x = attention!(operatorNorm(x), mask: mask, cache: cache)
+            r = attention!(operatorNorm(x), mask: mask, cache: cache)
         } else {
-            x = conv!(operatorNorm(x), cache: cache as? MambaCache)
+            r = conv!(operatorNorm(x), cache: cache as? MambaCache)
         }
-
-        x = x + residual
-        x = x + feedForward(ffnNorm(x))
-
-        return x
+        let h = x + r
+        let out = h + feedForward(ffnNorm(h))
+        return out
     }
 }
 
@@ -382,15 +324,13 @@ private class LFM2ModelInner: Module {
         let mask =
             mask
             ?? {
-                let firstAttnIdx = args.resolvedLayerTypes.firstIndex(of: "full_attention") ?? 0
-                let c = cache != nil ? [cache![firstAttnIdx]] : nil
+                let firstAttnIdx = args.fullAttnIdxs.first ?? 0
+                let c = cache != nil && firstAttnIdx < cache!.count ? [cache![firstAttnIdx]] : nil
                 return createAttentionMask(h: h, cache: c)
             }()
 
-        let resolvedCache: [KVCache?] = cache ?? Array(repeating: nil, count: layers.count)
-
-        for (layer, c) in zip(layers, resolvedCache) {
-            h = layer(h, mask: mask, cache: c)
+        for (i, layer) in layers.enumerated() {
+            h = layer(h, mask: mask, cache: cache?[i])
         }
 
         return embeddingNorm(h)
@@ -404,32 +344,20 @@ public class LFM2Model: Module, LLMModel, KVCacheDimensionProvider {
     private let model: LFM2ModelInner
     let configuration: LFM2Configuration
 
-    @ModuleInfo(key: "lm_head") var lmHead: Linear?
-
     public init(_ args: LFM2Configuration) {
         self.configuration = args
         self.vocabularySize = args.vocabularySize
 
-        self.kvHeads = args.resolvedLayerTypes.map { layerType in
-            layerType == "full_attention" ? args.kvHeads : 0
+        self.kvHeads = (0 ..< args.hiddenLayers).map { layerIdx in
+            args.fullAttnIdxs.contains(layerIdx) ? args.kvHeads : 0
         }
 
         self.model = LFM2ModelInner(args)
-
-        if !args.tieWordEmbeddings {
-            _lmHead.wrappedValue = Linear(args.hiddenSize, args.vocabularySize, bias: false)
-        }
     }
 
     public func callAsFunction(_ inputs: MLXArray, cache: [KVCache]?) -> MLXArray {
-        var out = model(inputs, cache: cache)
-
-        if let lmHead {
-            out = lmHead(out)
-        } else {
-            out = model.embedTokens.asLinear(out)
-        }
-        return out
+        let out = model(inputs, cache: cache)
+        return model.embedTokens.asLinear(out)
     }
 
     public func sanitize(weights: [String: MLXArray]) -> [String: MLXArray] {
@@ -439,7 +367,7 @@ public class LFM2Model: Module, LLMModel, KVCacheDimensionProvider {
             var sanitizedParam = param
 
             if name.contains("conv.weight") {
-                if param.shape.count > 2, param.shape[2] > param.shape[1] {
+                if param.shape[param.shape.count - 1] > param.shape[1] {
                     sanitizedParam = param.transposed(0, 2, 1)
                 }
             }
@@ -451,8 +379,8 @@ public class LFM2Model: Module, LLMModel, KVCacheDimensionProvider {
     }
 
     public func newCache(parameters: GenerateParameters?) -> [KVCache] {
-        configuration.resolvedLayerTypes.map { layerType in
-            if layerType == "full_attention" {
+        (0 ..< configuration.hiddenLayers).map { layerIdx in
+            if configuration.fullAttnIdxs.contains(layerIdx) {
                 KVCacheSimple()
             } else {
                 MambaCache()


### PR DESCRIPTION
I fixed the issues with the Swift port of LFM2 and aligned it closely with the Python implementation.

@johnmai-dev, since I've made some of these same mistakes in the past when using agentic tools, I would like to make the following suggestions:

- I always create a new folder in the base of the repo called `reference` and clone the Python mlx-lm repo into it, so that the agent has access to it.
- After an initial generation, start a fresh session with your tool of choice (Claude Code works well for me) and have the agent check to make sure the Swift implementation is closely aligned with the Python implementation. There are usually mistakes and inconsistencies that need to be fixed.
- Make sure the new Swift port aligns with the conventions used in existing Swift ports. Your initial version used computed properties prefixed with `resolved`, but the existing Swift ports use private optional properties prefixed with an underscore combined with public computed properties for fallback values.
- There's no substitute for manually checking the generated Swift code line by line against the original Python implementation. Inevitably, the agent will overlook some things, and you can prompt it to correct them.

Since this code will be used to train future AI models, aligning the Swift ports closely with the Python reference implementations will help future models learn MLX Swift syntax, which will make our job even easier in the future.

I haven't checked the other ports from @johnmai-dev that were recently merged, but it's possible that they have similar issues. If so, you can use the same techniques to clean them up.