### PR TITLE
fix: handle quantized tie-embedding for Gemma3Text

### DIFF
--- a/Libraries/MLXLLM/Models/Gemma3Text.swift
+++ b/Libraries/MLXLLM/Models/Gemma3Text.swift
@@ -362,8 +362,10 @@ public class Gemma3TextModel: Module, LLMModel {
         }
 
         if processedWeights["lm_head.weight"] == nil {
-            if let embedWeight = processedWeights["model.embed_tokens.weight"] {
-                processedWeights["lm_head.weight"] = embedWeight
+            ["weight", "scales", "biases"].forEach { key in
+                if let embedWeight = processedWeights["model.embed_tokens.\(key)"] {
+                    processedWeights["lm_head.\(key)"] = embedWeight
+                }
             }
         }
         return processedWeights


### PR DESCRIPTION
`Gemma3TextModel.santize` method can now handle quantized tie-embedding.