### PR TITLE
Add public init to ToolCall

### DIFF
--- a/Libraries/MLXLMCommon/Tool/ToolCall.swift
+++ b/Libraries/MLXLMCommon/Tool/ToolCall.swift
@@ -19,6 +19,10 @@ public struct ToolCall: Hashable, Codable, Sendable {
 
     /// The function to be called
     public let function: Function
+
+    public init(function: Function) {
+        self.function = function
+    }
 }
 
 extension ToolCall {


### PR DESCRIPTION
### Summary
This PR makes the ToolCall initializer public.

### Why
By exposing the initializer, it becomes possible to use MLX's ToolCall directly in, for instance, the [Swift MCP SDK](https://github.com/modelcontextprotocol/swift-sdk) using the `server.withMethodHandler(CallTool.self)` closure.

Example:

```swift
// MCP server implementation
 await server.withMethodHandler(CallTool.self) { id, params in
        // Create a ToolCall object that matches what ToolManager expects
        let toolCall = ToolCall(function: ToolCall.Function(name: params.name,
                                                       arguments: params.arguments ?? [:]))
        let resultString = try await toolManager.execute(toolCall: toolCall)
                
        return CallTool.Result(content: [.text(resultString)])
}           
```        