### PR TITLE
Fix LoRA fuse weight dtype

### DIFF
--- a/Libraries/MLXLMCommon/Adapters/LoRA/LoRA+Layers.swift
+++ b/Libraries/MLXLMCommon/Adapters/LoRA/LoRA+Layers.swift
@@ -171,8 +171,9 @@ public class QLoRALinear: QuantizedLinear, LoRALayer {
     /// - ``LoRATrain/fuse(model:layers:deQuantize:)``
     public func fused() -> Module {
         let weight = dequantizedWeight
-        let loraB = (scale * loraB.T).asType(.float16)
-        let loraA = loraA.T.asType(.float16)
+        let dtype = dequantizedWeight.dtype
+        let loraB = (scale * loraB.T).asType(dtype)
+        let loraA = loraA.T.asType(dtype)
         return QuantizedLinear(
             weight: weight + matmul(loraB, loraA),
             bias: bias,


### PR DESCRIPTION
# What

Fixed the resulting weight type after LoRA fusion. Previously, when fusing a quantized weight with `bfloat16` scales and a `float16` hardcoded dtype, the result was promoted to `float32`, causing a performance drop. With this fix, the fused weight now correctly retains the original weight’s dtype.

## Examples

Original model performance:
```
Prompt:     29 tokens, 1 018,793845 tokens/s
Generation: 222 tokens, 99,520063 tokens/s, 2,230706s
```

Fused (before fix, weight promoted to `float32`, which also increases memory consumption):
```
Prompt:     29 tokens, 1 119,732078 tokens/s
Generation: 238 tokens, 77,416602 tokens/s, 3,074276s
```

Fused (after fix):
```
Prompt:     29 tokens, 1 028,880913 tokens/s
Generation: 236 tokens, 99,972932 tokens/s, 2,360639s
```