### PR TITLE
Download subfolder configs apart HuggingFace Snapshot

### DIFF
--- a/Libraries/Embedders/Load.swift
+++ b/Libraries/Embedders/Load.swift
@@ -19,7 +19,7 @@ func prepareModelDirectory(
         case .id(let id):
             // download the model weights
             let repo = Hub.Repo(id: id)
-            let modelFiles = ["*.safetensors", "config.json"]
+            let modelFiles = ["*.safetensors", "config.json", "*/config.json"]
             return try await hub.snapshot(
                 from: repo, matching: modelFiles, progressHandler: progressHandler)
 


### PR DESCRIPTION
**Problem:** Configuration files located in subfolders are not downloaded when taking a HuggingFace model snapshot. This causes pooler configurations (like those in [sentence-transformers/all-MiniLM-L12-v2](https://huggingface.co/sentence-transformers/all-MiniLM-L12-v2)) to be missing from the download.

**Fix:** Extends the file pattern matching to include any `config.json` files found in immediate subdirectories, ensuring these configurations are downloaded.