### PR TITLE
Add periodic cache clearing during generation

### DIFF
--- a/Libraries/MLXLLM/LLMModel.swift
+++ b/Libraries/MLXLLM/LLMModel.swift
@@ -32,6 +32,7 @@ extension LLMModel {
             let result = self(input, cache: cache.isEmpty ? nil : cache, state: state)
             eval(cache)
             y = y[prefillStepSize...]
+            GPU.clearCache()
         }
 
         return .tokens(y)

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -623,7 +623,11 @@ public func generate(
         {
             break
         }
+
         tokens.append(token)
+        if tokens.count % 256 == 0 {
+            GPU.clearCache()
+        }
 
         if didGenerate(tokens) == .stop {
             break
@@ -713,6 +717,9 @@ public func generate(
         }
 
         tokenCount += 1
+        if tokenCount % 256 == 0 {
+            GPU.clearCache()
+        }
 
         // Invoke the callback with the current token
         if didGenerate(token) == .stop {
@@ -824,6 +831,9 @@ public func generate(
                 detokenizer.append(token: token)
                 if let chunk = detokenizer.next() {
                     tokenCount += 1
+                    if tokenCount % 256 == 0 {
+                        GPU.clearCache()
+                    }
 
                     // Process chunk through the tool call processor
                     if let textToYield = toolCallProcessor.processChunk(chunk) {


### PR DESCRIPTION
# What

When processing large inputs or generating large outputs, memory usage can be enormous. This PR adds periodic cache clearing during prompt processing and token generation. For prompt processing, we clear the cache every partial step, and it depends on the prefill window size. For token generation, we clear the cache every 256 tokens.