### PR TITLE
Add prefillStepSize to GenerateParameters init

### DIFF
--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -54,7 +54,7 @@ public protocol LogitProcessor: Sendable {
 public struct GenerateParameters: Sendable {
 
     /// Step size for processing the prompt
-    public var prefillStepSize = 512
+    public var prefillStepSize: Int
 
     /// Maximum tokens to generate
     public var maxTokens: Int?
@@ -67,22 +67,22 @@ public struct GenerateParameters: Sendable {
     public var kvBits: Int?
 
     /// Group size for KV cache quantization (default: 64)
-    public var kvGroupSize: Int = 64
+    public var kvGroupSize: Int
 
     /// Step to begin using a quantized KV cache when kvBits is non-nil (default: 0)
-    public var quantizedKVStart: Int = 0
+    public var quantizedKVStart: Int
 
     /// sampling temperature
-    public var temperature: Float = 0.6
+    public var temperature: Float
 
     /// top p sampling
-    public var topP: Float = 1.0
+    public var topP: Float
 
     /// penalty factor for repeating tokens
     public var repetitionPenalty: Float?
 
     /// number of tokens to consider for repetition penalty
-    public var repetitionContextSize: Int = 20
+    public var repetitionContextSize: Int
 
     public init(
         maxTokens: Int? = nil,
@@ -90,8 +90,11 @@ public struct GenerateParameters: Sendable {
         kvBits: Int? = nil,
         kvGroupSize: Int = 64,
         quantizedKVStart: Int = 0,
-        temperature: Float = 0.6, topP: Float = 1.0, repetitionPenalty: Float? = nil,
-        repetitionContextSize: Int = 20
+        temperature: Float = 0.6,
+        topP: Float = 1.0,
+        repetitionPenalty: Float? = nil,
+        repetitionContextSize: Int = 20,
+        prefillStepSize: Int = 512
     ) {
         self.maxTokens = maxTokens
         self.maxKVSize = maxKVSize
@@ -102,6 +105,7 @@ public struct GenerateParameters: Sendable {
         self.topP = topP
         self.repetitionPenalty = repetitionPenalty
         self.repetitionContextSize = repetitionContextSize
+        self.prefillStepSize = prefillStepSize
     }
 
     public func sampler() -> LogitSampler {


### PR DESCRIPTION
# What

It was not possible to pass the `prefillStepSize` argument. This PR adds it into `GenerateParameters.init` to make that possible. Default values have been removed from property declarations as they are defined in the init to make a single place where the default value could be changed.

## Suggestion

What do you think about changing the default value from 512 to 2048 to match the Python `mlx‑lm` version? I've been investigating the prompt‑processing differences, and the Python version was much faster, so I noticed a bigger prefill step and it worked well for me. For instance, processing 16,000 input tokens using Qwen3 0.6B achieves 2,100 tokens/s with a 512 window size and 2,600 tokens/s with a 2048 window size.