### PR TITLE
chore: upgrade swift-transformers to 1.1.2

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
-        "revision" : "c1805596154bb3a265fd91b8ac0c4433b4348fb0",
-        "version" : "1.2.0"
+        "revision" : "7b847a3b7008b2dc2f47ca3110d8c782fb2e5c7e",
+        "version" : "1.3.0"
       }
     },
     {
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/huggingface/swift-jinja.git",
       "state" : {
-        "revision" : "c1ef5963ba4a97a589b9c9583ff4ee3352a86d23",
-        "version" : "2.1.0"
+        "revision" : "38b7beeec5d968accd19a8a70c1882cc89979d1c",
+        "version" : "2.1.1"
       }
     },
     {
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-numerics",
       "state" : {
-        "revision" : "0a5bc04095a675662cf24757cc0640aa2204253b",
-        "version" : "1.0.2"
+        "revision" : "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
+        "version" : "1.1.1"
       }
     },
     {
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/huggingface/swift-transformers",
       "state" : {
-        "revision" : "94610577e4af9bbc267060af1e25e977604dd796",
-        "version" : "1.1.1"
+        "revision" : "d363e83a77bafe144808a3d01556139fe67cd8bc",
+        "version" : "1.1.2"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -30,7 +30,7 @@ let package = Package(
         .package(url: "https://github.com/ml-explore/mlx-swift", .upToNextMinor(from: "0.29.1")),
         .package(
             url: "https://github.com/huggingface/swift-transformers",
-            .upToNextMinor(from: "1.1.0")
+            .upToNextMinor(from: "1.1.2")
         ),
         .package(url: "https://github.com/1024jp/GzipSwift", "6.0.1" ... "6.0.1"),  // Only needed by MLXMNIST
     ],

--- a/mlx-swift-examples.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/mlx-swift-examples.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "b1d46b6ef52c730b3877c9d701e3dd2f90d14dbbd45684ac0e7c13511ff14f4b",
+  "originHash" : "71b9a52d45a0768676971f389fa9415274a1d781053f9b62ef4772aa3ae78f5a",
   "pins" : [
     {
       "identity" : "gzipswift",
@@ -105,8 +105,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/huggingface/swift-transformers",
       "state" : {
-        "revision" : "94610577e4af9bbc267060af1e25e977604dd796",
-        "version" : "1.1.1"
+        "revision" : "d363e83a77bafe144808a3d01556139fe67cd8bc",
+        "version" : "1.1.2"
       }
     }
   ],


### PR DESCRIPTION
Upgrade **swift-transformers** to 1.1.2.

This will allow to use with latest WhisperKit together, thanks! ☺️

Recently https://github.com/argmaxinc/WhisperKit upgraded to `0.15.0` which depends on **swift-transformers** `1.1.2` (latest as of today).

When I use both

```swift
    .package(url: "https://github.com/argmaxinc/WhisperKit", from: "0.15.0"),
    .package(url: "https://github.com/ml-explore/mlx-swift-examples", from: "2.29.1"),
```

I got error

```sh
  error: Dependencies could not be resolved because root depends on 'whisperkit' 0.15.0..<1.0.0 and root depends on 'mlx-swift-examples' 2.29.1..<3.0.0. 
  'mlx-swift-examples' is incompatible with 'whisperkit' because 'whisperkit' 0.15.0 depends on 'swift-transformers' 1.1.2..<1.2.0 and no versions of 'whisperkit' match the requirement 0.15.1..<1.0.0. 
  'mlx-swift-examples' >= 2.29.1 practically depends on 'swift-transformers' 1.0.0..<1.1.0 because 'mlx-swift-examples' 2.29.1 depends on 'swift-transformers' 1.0.0..<1.1.0 and no versions of 'mlx-swift-examples' match the requirement 2.29.2..<3.0.0. 
```

Because **mlx-swift-examples** relies on **swift-transformers** to `1.1.0`.

I am not sure if my update makes sense, would like to get some feedback, thanks!