### PR TITLE
improve handling of portrait display on iOS

### DIFF
--- a/Applications/LLMEval/ViewModels/LLMEvaluator.swift
+++ b/Applications/LLMEval/ViewModels/LLMEvaluator.swift
@@ -79,17 +79,18 @@ class LLMEvaluator {
 
     /// Load and return the model. Can be called multiple times; subsequent calls return the cached model.
     func load() async throws -> ModelContainer {
-        switch loadState {
-        case .idle:
-            return try await performLoad()
+        while true {
+            switch loadState {
+            case .idle:
+                return try await performLoad()
 
-        case .loading:
-            // Already loading, wait and retry
-            try await Task.sleep(nanoseconds: 100_000_000)  // 100ms
-            return try await load()
+            case .loading:
+                // Already loading, wait and retry
+                try await Task.sleep(for: .milliseconds(100))
 
-        case .loaded(let modelContainer):
-            return modelContainer
+            case .loaded(let modelContainer):
+                return modelContainer
+            }
         }
     }
 

--- a/Applications/LLMEval/Views/HeaderView.swift
+++ b/Applications/LLMEval/Views/HeaderView.swift
@@ -6,78 +6,112 @@ struct HeaderView: View {
     @Bindable var llm: LLMEvaluator
     @Binding var selectedDisplayStyle: ContentView.DisplayStyle
 
-    var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            // Model info with status
-            HStack {
-                VStack(alignment: .leading, spacing: 4) {
-                    Text("Model")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
+    @Environment(\.horizontalSizeClass) var horizontalSizeClass
 
-                    Text(llm.modelInfo)
-                        .font(.headline)
-                        .lineLimit(1)
-                }
+    var status: some View {
+        // Model info with status
+        HStack {
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Model")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
 
-                Spacer()
-
-                if llm.running {
-                    HStack(spacing: 8) {
-                        ProgressView()
-                            .controlSize(.small)
-                        Text("Generating...")
-                            .font(.subheadline)
-                            .foregroundStyle(.secondary)
-                    }
-                }
+                Text(llm.modelInfo)
+                    .font(.headline)
+                    .lineLimit(1)
             }
 
-            // Controls row
-            HStack(spacing: 16) {
-                HStack(spacing: 24) {
-                    Toggle("Tools", isOn: $llm.includeWeatherTool)
-                        .toggleStyle(.switch)
-                        .fixedSize()
-                        .help("Enable function calling with weather, math, and time tools")
+            Spacer()
 
-                    Toggle("Thinking", isOn: $llm.enableThinking)
-                        .toggleStyle(.switch)
-                        .fixedSize()
-                        .help("Enable thinking mode (supported by Qwen3)")
-
-                    // Max tokens slider
-                    VStack(alignment: .leading, spacing: 4) {
-                        Text("Max Tokens: \(llm.maxTokens)")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-
-                        Slider(
-                            value: Binding(
-                                get: { log2(Double(llm.maxTokens)) },
-                                set: { llm.maxTokens = Int(pow(2, $0)) }
-                            ),
-                            in: 10 ... 15,  // 2^10 (1024) to 2^15 (32768)
-                            step: 1
-                        )
-                        .frame(width: 120)
-                        .help("Maximum number of tokens to generate (1024-32768)")
-                    }
+            if llm.running {
+                HStack(spacing: 8) {
+                    ProgressView()
+                        .controlSize(.small)
+                    Text("Generating...")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
                 }
-
-                Spacer()
-
-                Picker("Display", selection: $selectedDisplayStyle) {
-                    ForEach(ContentView.DisplayStyle.allCases, id: \.self) { option in
-                        Text(option.rawValue.capitalized)
-                            .tag(option)
-                    }
-                }
-                .pickerStyle(.segmented)
-                .labelsHidden()
-                .frame(maxWidth: 180)
             }
         }
-        .padding(.bottom, 12)
+    }
+
+    var options: some View {
+        HStack(spacing: 24) {
+            Toggle("Tools", isOn: $llm.includeWeatherTool)
+                .toggleStyle(.switch)
+                .fixedSize()
+                .help("Enable function calling with weather, math, and time tools")
+
+            Toggle("Thinking", isOn: $llm.enableThinking)
+                .toggleStyle(.switch)
+                .fixedSize()
+                .help("Enable thinking mode (supported by Qwen3)")
+        }
+    }
+
+    var tokens: some View {
+        // Max tokens slider
+        VStack(alignment: .leading, spacing: 4) {
+            Text("Max Tokens: \(llm.maxTokens)")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            Slider(
+                value: Binding(
+                    get: { log2(Double(llm.maxTokens)) },
+                    set: { llm.maxTokens = Int(pow(2, $0)) }
+                ),
+                in: 10 ... 15,  // 2^10 (1024) to 2^15 (32768)
+                step: 1
+            )
+            .frame(width: 120)
+            .help("Maximum number of tokens to generate (1024-32768)")
+        }
+    }
+
+    var display: some View {
+        Picker("Display", selection: $selectedDisplayStyle) {
+            ForEach(ContentView.DisplayStyle.allCases, id: \.self) { option in
+                Text(option.rawValue.capitalized)
+                    .tag(option)
+            }
+        }
+        .pickerStyle(.segmented)
+        .labelsHidden()
+        .frame(maxWidth: 180)
+    }
+
+    var body: some View {
+        if horizontalSizeClass == .compact {
+            VStack {
+                status
+                DisclosureGroup("Controls") {
+                    VStack {
+                        options
+                        HStack {
+                            tokens
+                            display
+                        }
+                    }
+                }
+            }
+        } else {
+            VStack(alignment: .leading, spacing: 12) {
+                status
+
+                // Controls row
+                HStack(spacing: 16) {
+                    HStack(spacing: 24) {
+                        options
+                        tokens
+                    }
+
+                    Spacer()
+
+                    display
+                }
+            }
+            .padding(.bottom, 12)
+        }
     }
 }

--- a/Applications/LLMEval/Views/MetricsView.swift
+++ b/Applications/LLMEval/Views/MetricsView.swift
@@ -15,7 +15,20 @@ struct MetricsView: View {
 
     @State private var showMemoryDetails = false
 
+    @Environment(\.horizontalSizeClass) var horizontalSizeClass
+
     var body: some View {
+        if horizontalSizeClass == .compact {
+            DisclosureGroup("Statistics") {
+                stats
+                    .scaleEffect(0.8)
+            }
+        } else {
+            stats
+        }
+    }
+
+    var stats: some View {
         VStack(spacing: 12) {
             // Top row
             HStack(spacing: 12) {


### PR DESCRIPTION
## Proposed changes

Fix #456 

This isn't perfect, but the UI is usable on iOS portrait:

<img width="480" height="1040" alt="Screenshot 2026-01-05 at 2 07 13 PM" src="https://github.com/user-attachments/assets/5b69c3b0-e850-409e-a41e-7d8321b48463" />

Specifically on `horizontalSizeClass == .compact` this will use a `DisclosureGroup` for some of the controls and statistics.  It also uses a multi-line layout for the controls (this is specifically what broke the layout).

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
