### PR TITLE
fallback for finding padToken

### DIFF
--- a/Tools/embedder-tool/EmbedderRuntime+Embedding.swift
+++ b/Tools/embedder-tool/EmbedderRuntime+Embedding.swift
@@ -46,9 +46,9 @@ extension EmbedderRuntime {
                 )
             }
 
-            guard let padToken = tokenizer.eosTokenId else {
-                throw CommandError("Could not determine a padding token from the tokenizer.")
-            }
+            // [PAD] (BERT standard), EOS (autoregressive like Qwen)
+            let padToken = tokenizer.convertTokenToId("[PAD]") ?? tokenizer.eosTokenId ?? 0
+
             let maxLength = encoded.map { $0.1.count }.max() ?? 0
 
             let padded = stacked(


### PR DESCRIPTION
- fixes #457
- per @rudrankriyam "It looks for explicit [PAD] token (BERT standard), falls back to EOS token ID (autoregressive models like Qwen)"

this fixes e.g. nomic-ai/nomic-embed-text-v1.5

## Proposed changes

Please include a description of the problem or feature this PR is addressing. If there is a corresponding issue, include the issue #.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
