### PR TITLE
MLXChatExample: fix VLM image handling on iOS (PhotosPicker, EXIF, empty assistant trim)

### DIFF
--- a/Applications/MLXChatExample/ChatView.swift
+++ b/Applications/MLXChatExample/ChatView.swift
@@ -7,13 +7,50 @@
 
 import AVFoundation
 import AVKit
+import PhotosUI
 import SwiftUI
+import UniformTypeIdentifiers
+
+#if canImport(UIKit)
+import UIKit
+
+/// Transferable wrapper that explicitly requests image content type from PhotosPicker.
+private struct PickedImage: Transferable {
+    let data: Data
+
+    static var transferRepresentation: some TransferRepresentation {
+        DataRepresentation(importedContentType: .image) { data in
+            PickedImage(data: data)
+        }
+    }
+}
+
+/// Transferable wrapper for video content from PhotosPicker.
+private struct PickedVideo: Transferable {
+    let url: URL
+
+    static var transferRepresentation: some TransferRepresentation {
+        FileRepresentation(importedContentType: .movie) { receivedFile in
+            let dest = FileManager.default.temporaryDirectory
+                .appendingPathComponent(
+                    "\(UUID().uuidString).\(receivedFile.file.pathExtension)")
+            try FileManager.default.copyItem(at: receivedFile.file, to: dest)
+            return PickedVideo(url: dest)
+        }
+    }
+}
+#endif
 
 /// Main chat interface view that manages the conversation UI and user interactions.
 /// Displays messages, handles media attachments, and provides input controls.
 struct ChatView: View {
     /// View model that manages the chat state and business logic
     @Bindable private var vm: ChatViewModel
+
+    #if os(iOS)
+    /// Selected items from PhotosPicker
+    @State private var photosPickerItems: [PhotosPickerItem] = []
+    #endif
 
     /// Initializes the chat view with a view model
     /// - Parameter viewModel: The view model to manage chat state
@@ -51,11 +88,60 @@ struct ChatView: View {
                 ChatToolbarView(vm: vm)
             }
             // Handle media file selection
+            #if os(iOS)
+            .photosPicker(
+                isPresented: $vm.mediaSelection.isShowing,
+                selection: $photosPickerItems,
+                maxSelectionCount: 1,
+                matching: .any(of: [.images, .videos])
+            )
+            .onChange(of: photosPickerItems) {
+                Task {
+                    for item in photosPickerItems {
+                        if item.supportedContentTypes.contains(where: {
+                            $0.conforms(to: .image)
+                        }) {
+                            // Load image with explicit .image content type
+                            if let picked = try? await item.loadTransferable(
+                                type: PickedImage.self),
+                                let uiImage = UIImage(data: picked.data)
+                            {
+                                // Normalize orientation so pixels match the display orientation.
+                                // UIImage.jpegData() only writes an EXIF tag but CIImage(contentsOf:)
+                                // does not apply it, so the VLM would receive a rotated image.
+                                let renderer = UIGraphicsImageRenderer(size: uiImage.size)
+                                let oriented = renderer.image { _ in
+                                    uiImage.draw(in: CGRect(origin: .zero, size: uiImage.size))
+                                }
+                                if let jpegData = oriented.jpegData(compressionQuality: 0.9) {
+                                    let url =
+                                        FileManager.default.temporaryDirectory
+                                        .appendingPathComponent("\(UUID().uuidString).jpg")
+                                    try? jpegData.write(to: url)
+                                    vm.addMedia(.success(url))
+                                }
+                            }
+                        } else if item.supportedContentTypes.contains(where: {
+                            $0.conforms(to: .movie)
+                        }) {
+                            // Load video with explicit .movie content type
+                            if let picked = try? await item.loadTransferable(
+                                type: PickedVideo.self)
+                            {
+                                vm.addMedia(.success(picked.url))
+                            }
+                        }
+                    }
+                    photosPickerItems = []
+                }
+            }
+            #else
             .fileImporter(
                 isPresented: $vm.mediaSelection.isShowing,
                 allowedContentTypes: [.image, .movie],
                 onCompletion: vm.addMedia
             )
+            #endif
         }
     }
 }

--- a/Applications/MLXChatExample/ChatView.swift
+++ b/Applications/MLXChatExample/ChatView.swift
@@ -12,33 +12,33 @@ import SwiftUI
 import UniformTypeIdentifiers
 
 #if canImport(UIKit)
-import UIKit
+    import UIKit
 
-/// Transferable wrapper that explicitly requests image content type from PhotosPicker.
-private struct PickedImage: Transferable {
-    let data: Data
+    /// Transferable wrapper that explicitly requests image content type from PhotosPicker.
+    private struct PickedImage: Transferable {
+        let data: Data
 
-    static var transferRepresentation: some TransferRepresentation {
-        DataRepresentation(importedContentType: .image) { data in
-            PickedImage(data: data)
+        static var transferRepresentation: some TransferRepresentation {
+            DataRepresentation(importedContentType: .image) { data in
+                PickedImage(data: data)
+            }
         }
     }
-}
 
-/// Transferable wrapper for video content from PhotosPicker.
-private struct PickedVideo: Transferable {
-    let url: URL
+    /// Transferable wrapper for video content from PhotosPicker.
+    private struct PickedVideo: Transferable {
+        let url: URL
 
-    static var transferRepresentation: some TransferRepresentation {
-        FileRepresentation(importedContentType: .movie) { receivedFile in
-            let dest = FileManager.default.temporaryDirectory
-                .appendingPathComponent(
-                    "\(UUID().uuidString).\(receivedFile.file.pathExtension)")
-            try FileManager.default.copyItem(at: receivedFile.file, to: dest)
-            return PickedVideo(url: dest)
+        static var transferRepresentation: some TransferRepresentation {
+            FileRepresentation(importedContentType: .movie) { receivedFile in
+                let dest = FileManager.default.temporaryDirectory
+                    .appendingPathComponent(
+                        "\(UUID().uuidString).\(receivedFile.file.pathExtension)")
+                try FileManager.default.copyItem(at: receivedFile.file, to: dest)
+                return PickedVideo(url: dest)
+            }
         }
     }
-}
 #endif
 
 /// Main chat interface view that manages the conversation UI and user interactions.
@@ -48,8 +48,8 @@ struct ChatView: View {
     @Bindable private var vm: ChatViewModel
 
     #if os(iOS)
-    /// Selected items from PhotosPicker
-    @State private var photosPickerItems: [PhotosPickerItem] = []
+        /// Selected items from PhotosPicker
+        @State private var photosPickerItems: [PhotosPickerItem] = []
     #endif
 
     /// Initializes the chat view with a view model
@@ -89,58 +89,58 @@ struct ChatView: View {
             }
             // Handle media file selection
             #if os(iOS)
-            .photosPicker(
-                isPresented: $vm.mediaSelection.isShowing,
-                selection: $photosPickerItems,
-                maxSelectionCount: 1,
-                matching: .any(of: [.images, .videos])
-            )
-            .onChange(of: photosPickerItems) {
-                Task {
-                    for item in photosPickerItems {
-                        if item.supportedContentTypes.contains(where: {
-                            $0.conforms(to: .image)
-                        }) {
-                            // Load image with explicit .image content type
-                            if let picked = try? await item.loadTransferable(
-                                type: PickedImage.self),
-                                let uiImage = UIImage(data: picked.data)
-                            {
-                                // Normalize orientation so pixels match the display orientation.
-                                // UIImage.jpegData() only writes an EXIF tag but CIImage(contentsOf:)
-                                // does not apply it, so the VLM would receive a rotated image.
-                                let renderer = UIGraphicsImageRenderer(size: uiImage.size)
-                                let oriented = renderer.image { _ in
-                                    uiImage.draw(in: CGRect(origin: .zero, size: uiImage.size))
-                                }
-                                if let jpegData = oriented.jpegData(compressionQuality: 0.9) {
-                                    let url =
-                                        FileManager.default.temporaryDirectory
+                .photosPicker(
+                    isPresented: $vm.mediaSelection.isShowing,
+                    selection: $photosPickerItems,
+                    maxSelectionCount: 1,
+                    matching: .any(of: [.images, .videos])
+                )
+                .onChange(of: photosPickerItems) {
+                    Task {
+                        for item in photosPickerItems {
+                            if item.supportedContentTypes.contains(where: {
+                                $0.conforms(to: .image)
+                            }) {
+                                // Load image with explicit .image content type
+                                if let picked = try? await item.loadTransferable(
+                                    type: PickedImage.self),
+                                    let uiImage = UIImage(data: picked.data)
+                                {
+                                    // Normalize orientation so pixels match the display orientation.
+                                    // UIImage.jpegData() only writes an EXIF tag but CIImage(contentsOf:)
+                                    // does not apply it, so the VLM would receive a rotated image.
+                                    let renderer = UIGraphicsImageRenderer(size: uiImage.size)
+                                    let oriented = renderer.image { _ in
+                                        uiImage.draw(in: CGRect(origin: .zero, size: uiImage.size))
+                                    }
+                                    if let jpegData = oriented.jpegData(compressionQuality: 0.9) {
+                                        let url =
+                                            FileManager.default.temporaryDirectory
                                         .appendingPathComponent("\(UUID().uuidString).jpg")
-                                    try? jpegData.write(to: url)
-                                    vm.addMedia(.success(url))
+                                        try? jpegData.write(to: url)
+                                        vm.addMedia(.success(url))
+                                    }
                                 }
-                            }
-                        } else if item.supportedContentTypes.contains(where: {
-                            $0.conforms(to: .movie)
-                        }) {
-                            // Load video with explicit .movie content type
-                            if let picked = try? await item.loadTransferable(
-                                type: PickedVideo.self)
-                            {
-                                vm.addMedia(.success(picked.url))
+                            } else if item.supportedContentTypes.contains(where: {
+                                $0.conforms(to: .movie)
+                            }) {
+                                // Load video with explicit .movie content type
+                                if let picked = try? await item.loadTransferable(
+                                    type: PickedVideo.self)
+                                {
+                                    vm.addMedia(.success(picked.url))
+                                }
                             }
                         }
+                        photosPickerItems = []
                     }
-                    photosPickerItems = []
                 }
-            }
             #else
-            .fileImporter(
-                isPresented: $vm.mediaSelection.isShowing,
-                allowedContentTypes: [.image, .movie],
-                onCompletion: vm.addMedia
-            )
+                .fileImporter(
+                    isPresented: $vm.mediaSelection.isShowing,
+                    allowedContentTypes: [.image, .movie],
+                    onCompletion: vm.addMedia
+                )
             #endif
         }
     }

--- a/Applications/MLXChatExample/Services/MLXService.swift
+++ b/Applications/MLXChatExample/Services/MLXService.swift
@@ -97,8 +97,15 @@ class MLXService {
         // Load or retrieve model from cache
         let modelContainer = try await load(model: model)
 
+        // Exclude trailing empty assistant message so the chat template
+        // leaves the assistant turn open for generation (matching ChatSession behavior)
+        var inputMessages = messages
+        if let last = inputMessages.last, last.role == .assistant, last.content.isEmpty {
+            inputMessages.removeLast()
+        }
+
         // Map app-specific Message type to Chat.Message for model input
-        let chat = messages.map { message in
+        let chat = inputMessages.map { message in
             let role: Chat.Message.Role =
                 switch message.role {
                 case .assistant:


### PR DESCRIPTION
## Summary

Three iOS-only fixes in \`MLXChatExample\` so VLM image input actually works on iPhone:

1. **PhotosPicker instead of \`fileImporter\`** — \`fileImporter\` shows the Files app on iOS, which doesn't expose the photo library. Replace with \`.photosPicker\` for image / video selection. Custom \`Transferable\` wrappers (\`PickedImage\` / \`PickedVideo\`) request the right content type explicitly so loading is reliable.

2. **Normalize EXIF orientation before saving** — \`UIImage.jpegData()\` writes the EXIF orientation tag but leaves pixel data in raw sensor orientation. \`CIImage(contentsOf:)\` (used downstream for the model input) does **not** apply that EXIF tag, so portrait / landscape photos arrive at the VLM rotated. Re-render through \`UIGraphicsImageRenderer\` before writing the JPEG so the file is upright.

3. **Trim trailing empty assistant message before applying chat template** — \`ChatViewModel\` appends an empty assistant message before generation starts (so the UI has a placeholder to stream into). When that vector is passed straight into the chat template, the template closes the assistant turn and the model emits an EOS immediately. Strip the trailing empty assistant entry, matching the implicit behavior of \`ChatSession\`.

macOS path unchanged — \`fileImporter\` still works there. The \`#if os(iOS)\` blocks are scoped to the new code only.

## Test plan

Tested on iPhone (Daisuke の iPhone, iOS 26):

- [x] qwen2.5-VL-3B-Instruct-4bit, photo selected from Photos → image preview shown.
- [ ] Re-test landscape / portrait image after merge: \"describe this image\" output should match the visible orientation.
- [ ] Video selection still working.
- [ ] Successive sends without restarting the chat.