### PR TITLE
MLXChatExample: register Gemma 4 (E2B / E4B) VLMs

### DIFF
--- a/Applications/MLXChatExample/Services/MLXService.swift
+++ b/Applications/MLXChatExample/Services/MLXService.swift
@@ -32,6 +32,8 @@ class MLXService {
             name: "qwen2.5VL:3b", configuration: VLMRegistry.qwen2_5VL3BInstruct4Bit, type: .vlm),
         LMModel(name: "qwen2VL:2b", configuration: VLMRegistry.qwen2VL2BInstruct4Bit, type: .vlm),
         LMModel(name: "smolVLM", configuration: VLMRegistry.smolvlminstruct4bit, type: .vlm),
+        LMModel(name: "gemma4:E2B", configuration: VLMRegistry.gemma4_E2B_it_4bit, type: .vlm),
+        LMModel(name: "gemma4:E4B", configuration: VLMRegistry.gemma4_E4B_it_4bit, type: .vlm),
         LMModel(name: "acereason:7B", configuration: LLMRegistry.acereason_7b_4bit, type: .llm),
         LMModel(name: "gemma3n:E2B", configuration: LLMRegistry.gemma3n_E2B_it_lm_4bit, type: .llm),
         LMModel(name: "gemma3n:E4B", configuration: LLMRegistry.gemma3n_E4B_it_lm_4bit, type: .llm),


### PR DESCRIPTION
## Summary

Registers the two smaller Gemma 4 VLM checkpoints already published in \`VLMRegistry\` (\`gemma4_E2B_it_4bit\`, \`gemma4_E4B_it_4bit\`) in MLXChatExample's \`availableModels\`, so they appear alongside the existing qwen / smol VLMs in the model picker on macOS and iOS. The 31B and 26BA4B variants are intentionally left out — too large to be practical on supported iOS devices.

Depends on (or coexists with) https://github.com/ml-explore/mlx-swift-lm/pull/256 for video support; image and text input work today against any Gemma 4 mlx-swift-lm release that ships the model registration (already merged via #180 / #185).

## Verification

- ✅ \`xcodebuild MLXChatExample\` builds for macOS arm64, generic iOS Simulator, and generic iOS Device.
- ✅ **On-device iOS verified — iPhone 17 Pro, \`gemma4:E2B\` selected from the picker, 8 s video → 42.53 tok/s decode, transcript matched the video content.** (Run against a build that includes ml-explore/mlx-swift-lm#256.)

## Test plan

- [x] macOS / iOS Simulator / iOS device all build.
- [x] On-device run on iPhone 17 Pro produces a coherent transcript for an 8 s video clip at 42.53 tok/s.