### PR TITLE
Improve MLXChatExample app

### DIFF
--- a/Applications/MLXChatExample/Models/LMModel.swift
+++ b/Applications/MLXChatExample/Models/LMModel.swift
@@ -10,8 +10,11 @@ import MLXLMCommon
 /// Represents a language model configuration with its associated properties and type.
 /// Can represent either a large language model (LLM) or a vision-language model (VLM).
 struct LMModel {
-    /// Name of the model
+    /// Identifier for the model, used for cache keys and equality.
     let name: String
+
+    /// User-facing label shown in the model picker.
+    let displayName: String
 
     /// Configuration settings for model initialization
     let configuration: ModelConfiguration
@@ -31,15 +34,6 @@ struct LMModel {
 // MARK: - Helpers
 
 extension LMModel {
-    /// Display name with additional "(Vision)" suffix for vision models
-    var displayName: String {
-        if isVisionModel {
-            "\(name) (Vision)"
-        } else {
-            name
-        }
-    }
-
     /// Whether the model is a large language model
     var isLanguageModel: Bool {
         type == .llm

--- a/Applications/MLXChatExample/Services/MLXService.swift
+++ b/Applications/MLXChatExample/Services/MLXService.swift
@@ -21,29 +21,60 @@ class MLXService {
     /// List of available models that can be used for generation.
     /// Includes both language models (LLM) and vision-language models (VLM).
     static let availableModels: [LMModel] = [
-        LMModel(name: "llama3.2:1b", configuration: LLMRegistry.llama3_2_1B_4bit, type: .llm),
-        LMModel(name: "qwen2.5:1.5b", configuration: LLMRegistry.qwen2_5_1_5b, type: .llm),
-        LMModel(name: "smolLM:135m", configuration: LLMRegistry.smolLM_135M_4bit, type: .llm),
-        LMModel(name: "qwen3:0.6b", configuration: LLMRegistry.qwen3_0_6b_4bit, type: .llm),
-        LMModel(name: "qwen3:1.7b", configuration: LLMRegistry.qwen3_1_7b_4bit, type: .llm),
-        LMModel(name: "qwen3:4b", configuration: LLMRegistry.qwen3_4b_4bit, type: .llm),
-        LMModel(name: "qwen3:8b", configuration: LLMRegistry.qwen3_8b_4bit, type: .llm),
         LMModel(
-            name: "qwen2.5VL:3b", configuration: VLMRegistry.qwen2_5VL3BInstruct4Bit, type: .vlm),
-        LMModel(name: "qwen2VL:2b", configuration: VLMRegistry.qwen2VL2BInstruct4Bit, type: .vlm),
-        LMModel(name: "smolVLM", configuration: VLMRegistry.smolvlminstruct4bit, type: .vlm),
-        LMModel(name: "acereason:7B", configuration: LLMRegistry.acereason_7b_4bit, type: .llm),
-        LMModel(name: "gemma3n:E2B", configuration: LLMRegistry.gemma3n_E2B_it_lm_4bit, type: .llm),
-        LMModel(name: "gemma3n:E4B", configuration: LLMRegistry.gemma3n_E4B_it_lm_4bit, type: .llm),
+            name: "llama3.2:1b", displayName: "Llama 3.2 (1B)",
+            configuration: LLMRegistry.llama3_2_1B_4bit, type: .llm),
+        LMModel(
+            name: "qwen2.5:1.5b", displayName: "Qwen 2.5 (1.5B)",
+            configuration: LLMRegistry.qwen2_5_1_5b, type: .llm),
+        LMModel(
+            name: "smolLM:135m", displayName: "SmolLM (135M)",
+            configuration: LLMRegistry.smolLM_135M_4bit, type: .llm),
+        LMModel(
+            name: "qwen3:0.6b", displayName: "Qwen 3 (0.6B)",
+            configuration: LLMRegistry.qwen3_0_6b_4bit, type: .llm),
+        LMModel(
+            name: "qwen3:1.7b", displayName: "Qwen 3 (1.7B)",
+            configuration: LLMRegistry.qwen3_1_7b_4bit, type: .llm),
+        LMModel(
+            name: "qwen3:4b", displayName: "Qwen 3 (4B)",
+            configuration: LLMRegistry.qwen3_4b_4bit, type: .llm),
+        LMModel(
+            name: "qwen3:8b", displayName: "Qwen 3 (8B)",
+            configuration: LLMRegistry.qwen3_8b_4bit, type: .llm),
+        LMModel(
+            name: "qwen2.5VL:3b", displayName: "Qwen 2.5 VL (3B)",
+            configuration: VLMRegistry.qwen2_5VL3BInstruct4Bit, type: .vlm),
+        LMModel(
+            name: "qwen2VL:2b", displayName: "Qwen 2 VL (2B)",
+            configuration: VLMRegistry.qwen2VL2BInstruct4Bit, type: .vlm),
+        LMModel(
+            name: "smolVLM", displayName: "SmolVLM",
+            configuration: VLMRegistry.smolvlminstruct4bit, type: .vlm),
+        LMModel(
+            name: "acereason:7B", displayName: "AceReason (7B)",
+            configuration: LLMRegistry.acereason_7b_4bit, type: .llm),
+        LMModel(
+            name: "gemma3n:E2B", displayName: "Gemma 3n (E2B)",
+            configuration: LLMRegistry.gemma3n_E2B_it_lm_4bit, type: .llm),
+        LMModel(
+            name: "gemma3n:E4B", displayName: "Gemma 3n (E4B)",
+            configuration: LLMRegistry.gemma3n_E4B_it_lm_4bit, type: .llm),
     ]
 
     /// Cache to store loaded model containers to avoid reloading.
     private let modelCache = NSCache<NSString, ModelContainer>()
 
     /// Tracks the current model download progress.
-    /// Access this property to monitor model download status.
+    /// Non-nil only while bytes are actively flowing from the network.
     @MainActor
     private(set) var modelDownloadProgress: Progress?
+
+    /// Whether a model is currently being initialized into memory.
+    /// True for the entire `loadContainer` call, including the disk → memory phase
+    /// after any network download has finished.
+    @MainActor
+    private(set) var isLoadingModel = false
 
     /// Loads a model from the hub or retrieves it from cache.
     /// - Parameter model: The model configuration to load
@@ -58,7 +89,7 @@ class MLXService {
             return container
         } else {
             // Select appropriate factory based on model type
-            let factory: ModelFactory =
+            let factory: any ModelFactory =
                 switch model.type {
                 case .llm:
                     LLMModelFactory.shared
@@ -69,14 +100,29 @@ class MLXService {
             let downloader = #hubDownloader()
             let loader = #huggingFaceTokenizerLoader()
 
-            // Load model and track download progress
+            await MainActor.run { self.isLoadingModel = true }
+            defer {
+                Task { @MainActor in
+                    self.modelDownloadProgress = nil
+                    self.isLoadingModel = false
+                }
+            }
+
+            // Load model and track download progress. Clear the progress as soon as
+            // the downloader reports completion so the loading-into-memory phase is
+            // represented by `isLoadingModel` alone.
             let container = try await factory.loadContainer(
                 from: downloader,
                 using: loader,
                 configuration: model.configuration
             ) { progress in
                 Task { @MainActor in
-                    self.modelDownloadProgress = progress
+                    guard self.isLoadingModel else { return }
+                    if progress.isFinished {
+                        self.modelDownloadProgress = nil
+                    } else {
+                        self.modelDownloadProgress = progress
+                    }
                 }
             }
 
@@ -122,7 +168,8 @@ class MLXService {
             chat: chat, processing: .init(resize: .init(width: 1024, height: 1024)))
 
         // Generate response using the model
-        return try await modelContainer.perform { (context: ModelContext) in
+        return try await modelContainer.perform(nonSendable: userInput) {
+            (context: ModelContext, userInput: UserInput) in
             let lmInput = try await context.processor.prepare(input: userInput)
             // Set temperature for response randomness (0.7 provides good balance)
             let parameters = GenerateParameters(temperature: 0.7)

--- a/Applications/MLXChatExample/Services/MLXService.swift
+++ b/Applications/MLXChatExample/Services/MLXService.swift
@@ -67,8 +67,9 @@ class MLXService {
             configuration: LLMRegistry.gemma3n_E4B_it_lm_4bit, type: .llm),
     ]
 
-    /// System instructions applied to each new `ChatSession`.
-    private let instructions = "You are a helpful assistant."
+    /// System prompt applied to each new `ChatSession` (as `instructions`) and
+    /// shown in the chat as the system message.
+    static let systemPrompt = "You are a helpful assistant."
 
     /// Generation parameters applied to each new `ChatSession`.
     private let generateParameters = GenerateParameters(temperature: 0.7)
@@ -153,7 +154,7 @@ class MLXService {
         let container = try await load(model: model)
         let session = ChatSession(
             container,
-            instructions: instructions,
+            instructions: Self.systemPrompt,
             history: history,
             generateParameters: generateParameters,
             processing: .init(resize: .init(width: 1024, height: 1024))

--- a/Applications/MLXChatExample/Services/MLXService.swift
+++ b/Applications/MLXChatExample/Services/MLXService.swift
@@ -15,12 +15,20 @@ import MLXVLM
 import Tokenizers
 
 /// A service class that manages machine learning models for text and vision-language tasks.
-/// This class handles model loading, caching, and text generation using various LLM and VLM models.
+/// Holds a single active `ChatSession` so KV-cache state is reused across turns
+/// without re-feeding the visible message array. When the selected model changes,
+/// the session is rebuilt and seeded with the current visible chat history so the
+/// new model can continue the conversation.
 @Observable
+@MainActor
 class MLXService {
     /// List of available models that can be used for generation.
     /// Includes both language models (LLM) and vision-language models (VLM).
+    /// `qwen3:4b` is listed first so it is the default selection on a fresh launch.
     static let availableModels: [LMModel] = [
+        LMModel(
+            name: "qwen3:4b", displayName: "Qwen 3 (4B)",
+            configuration: LLMRegistry.qwen3_4b_4bit, type: .llm),
         LMModel(
             name: "llama3.2:1b", displayName: "Llama 3.2 (1B)",
             configuration: LLMRegistry.llama3_2_1B_4bit, type: .llm),
@@ -36,9 +44,6 @@ class MLXService {
         LMModel(
             name: "qwen3:1.7b", displayName: "Qwen 3 (1.7B)",
             configuration: LLMRegistry.qwen3_1_7b_4bit, type: .llm),
-        LMModel(
-            name: "qwen3:4b", displayName: "Qwen 3 (4B)",
-            configuration: LLMRegistry.qwen3_4b_4bit, type: .llm),
         LMModel(
             name: "qwen3:8b", displayName: "Qwen 3 (8B)",
             configuration: LLMRegistry.qwen3_8b_4bit, type: .llm),
@@ -62,120 +67,130 @@ class MLXService {
             configuration: LLMRegistry.gemma3n_E4B_it_lm_4bit, type: .llm),
     ]
 
-    /// Cache to store loaded model containers to avoid reloading.
+    /// System instructions applied to each new `ChatSession`.
+    private let instructions = "You are a helpful assistant."
+
+    /// Generation parameters applied to each new `ChatSession`.
+    private let generateParameters = GenerateParameters(temperature: 0.7)
+
+    /// Cache of loaded model containers, keyed by `LMModel.name`.
     private let modelCache = NSCache<NSString, ModelContainer>()
+
+    /// The currently active session, owning the KV cache for `currentModel`.
+    /// Rebuilt with seeded history whenever the selected model changes.
+    private var currentSession: ChatSession?
+
+    /// The model that `currentSession` was built for. Used to detect a model
+    /// switch on the next call to ``generate(history:prompt:images:videos:model:)``.
+    private var currentModel: LMModel?
 
     /// Tracks the current model download progress.
     /// Non-nil only while bytes are actively flowing from the network.
-    @MainActor
     private(set) var modelDownloadProgress: Progress?
 
     /// Whether a model is currently being initialized into memory.
     /// True for the entire `loadContainer` call, including the disk → memory phase
     /// after any network download has finished.
-    @MainActor
     private(set) var isLoadingModel = false
 
     /// Loads a model from the hub or retrieves it from cache.
-    /// - Parameter model: The model configuration to load
-    /// - Returns: A ModelContainer instance containing the loaded model
-    /// - Throws: Errors that might occur during model loading
     private func load(model: LMModel) async throws -> ModelContainer {
         // Set GPU memory limit to prevent out of memory issues
         Memory.cacheLimit = 20 * 1024 * 1024
 
-        // Return cached model if available to avoid reloading
         if let container = modelCache.object(forKey: model.name as NSString) {
             return container
-        } else {
-            // Select appropriate factory based on model type
-            let factory: any ModelFactory =
-                switch model.type {
-                case .llm:
-                    LLMModelFactory.shared
-                case .vlm:
-                    VLMModelFactory.shared
-                }
-
-            let downloader = #hubDownloader()
-            let loader = #huggingFaceTokenizerLoader()
-
-            await MainActor.run { self.isLoadingModel = true }
-            defer {
-                Task { @MainActor in
-                    self.modelDownloadProgress = nil
-                    self.isLoadingModel = false
-                }
-            }
-
-            // Load model and track download progress. Clear the progress as soon as
-            // the downloader reports completion so the loading-into-memory phase is
-            // represented by `isLoadingModel` alone.
-            let container = try await factory.loadContainer(
-                from: downloader,
-                using: loader,
-                configuration: model.configuration
-            ) { progress in
-                Task { @MainActor in
-                    guard self.isLoadingModel else { return }
-                    if progress.isFinished {
-                        self.modelDownloadProgress = nil
-                    } else {
-                        self.modelDownloadProgress = progress
-                    }
-                }
-            }
-
-            // Cache the loaded model for future use
-            modelCache.setObject(container, forKey: model.name as NSString)
-
-            return container
         }
+
+        let factory: any ModelFactory =
+            switch model.type {
+            case .llm:
+                LLMModelFactory.shared
+            case .vlm:
+                VLMModelFactory.shared
+            }
+
+        let downloader = #hubDownloader()
+        let loader = #huggingFaceTokenizerLoader()
+
+        isLoadingModel = true
+        defer {
+            modelDownloadProgress = nil
+            isLoadingModel = false
+        }
+
+        let container = try await factory.loadContainer(
+            from: downloader,
+            using: loader,
+            configuration: model.configuration
+        ) { progress in
+            Task { @MainActor in
+                guard self.isLoadingModel else { return }
+                if progress.isFinished {
+                    self.modelDownloadProgress = nil
+                } else {
+                    self.modelDownloadProgress = progress
+                }
+            }
+        }
+
+        modelCache.setObject(container, forKey: model.name as NSString)
+        return container
     }
 
-    /// Generates text based on the provided messages using the specified model.
-    /// - Parameters:
-    ///   - messages: Array of chat messages including user, assistant, and system messages
-    ///   - model: The language model to use for generation
-    /// - Returns: An AsyncStream of generated text tokens
-    /// - Throws: Errors that might occur during generation
-    func generate(messages: [Message], model: LMModel) async throws -> AsyncStream<Generation> {
-        // Load or retrieve model from cache
-        let modelContainer = try await load(model: model)
-
-        // Map app-specific Message type to Chat.Message for model input
-        let chat = messages.map { message in
-            let role: Chat.Message.Role =
-                switch message.role {
-                case .assistant:
-                    .assistant
-                case .user:
-                    .user
-                case .system:
-                    .system
-                }
-
-            // Process any attached media for VLM models
-            let images: [UserInput.Image] = message.images.map { imageURL in .url(imageURL) }
-            let videos: [UserInput.Video] = message.videos.map { videoURL in .url(videoURL) }
-
-            return Chat.Message(
-                role: role, content: message.content, images: images, videos: videos)
+    /// Returns the active `ChatSession`, rebuilding it (seeded with `history`)
+    /// whenever the selected model changes or no session is yet active.
+    ///
+    /// `history` is only consumed on a rebuild; for follow-up turns on the same
+    /// model the existing session is reused so KV-cache state is preserved.
+    private func session(
+        for model: LMModel,
+        history: [Chat.Message]
+    ) async throws -> ChatSession {
+        if let currentSession, currentModel?.id == model.id {
+            return currentSession
         }
+        let container = try await load(model: model)
+        let session = ChatSession(
+            container,
+            instructions: instructions,
+            history: history,
+            generateParameters: generateParameters,
+            processing: .init(resize: .init(width: 1024, height: 1024))
+        )
+        currentSession = session
+        currentModel = model
+        return session
+    }
 
-        // Prepare input for model processing
-        let userInput = UserInput(
-            chat: chat, processing: .init(resize: .init(width: 1024, height: 1024)))
+    /// Streams the model's response to the next prompt/media turn.
+    ///
+    /// `history` carries the prior conversation (excluding the system prompt and
+    /// the new turn being submitted). It is used to seed a fresh session when the
+    /// selected model has changed since the previous call; otherwise the existing
+    /// session already knows the prior turns and `history` is ignored.
+    func generate(
+        history: [Chat.Message],
+        prompt: String,
+        images: [URL] = [],
+        videos: [URL] = [],
+        model: LMModel
+    ) async throws -> AsyncThrowingStream<Generation, Error> {
+        let session = try await session(for: model, history: history)
+        let userImages = images.map { UserInput.Image.url($0) }
+        let userVideos = videos.map { UserInput.Video.url($0) }
 
-        // Generate response using the model
-        return try await modelContainer.perform(nonSendable: userInput) {
-            (context: ModelContext, userInput: UserInput) in
-            let lmInput = try await context.processor.prepare(input: userInput)
-            // Set temperature for response randomness (0.7 provides good balance)
-            let parameters = GenerateParameters(temperature: 0.7)
+        return session.streamDetails(
+            to: prompt,
+            images: userImages,
+            videos: userVideos
+        )
+    }
 
-            return try MLXLMCommon.generate(
-                input: lmInput, parameters: parameters, context: context)
-        }
+    /// Drops the active session so the next call to ``generate(history:prompt:images:videos:model:)``
+    /// builds a fresh one (with whatever history the caller passes at that time).
+    func clearSession() {
+        currentSession = nil
+        currentModel = nil
     }
 }

--- a/Applications/MLXChatExample/Services/MLXService.swift
+++ b/Applications/MLXChatExample/Services/MLXService.swift
@@ -65,6 +65,18 @@ class MLXService {
         LMModel(
             name: "gemma3n:E4B", displayName: "Gemma 3n (E4B)",
             configuration: LLMRegistry.gemma3n_E4B_it_lm_4bit, type: .llm),
+        LMModel(
+            name: "gpt-oss:20b", displayName: "GPT-OSS (20B, MXFP4 Q8)",
+            configuration: LLMRegistry.gpt_oss_20b_MXFP4_Q8, type: .llm),
+        LMModel(
+            name: "granite4:tiny", displayName: "Granite 4.0 H Tiny (4-bit DWQ)",
+            configuration: LLMRegistry.granite_4_0_h_tiny_4bit_dwq, type: .llm),
+        LMModel(
+            name: "gemma4:E2B", displayName: "Gemma 4 (E2B)",
+            configuration: LLMRegistry.gemma4_e2b_it_4bit, type: .llm),
+        LMModel(
+            name: "lfm2:1.2b", displayName: "LFM2 (1.2B)",
+            configuration: LLMRegistry.lfm2_1_2b_4bit, type: .llm),
     ]
 
     /// System prompt applied to each new `ChatSession` (as `instructions`) and

--- a/Applications/MLXChatExample/ViewModels/ChatViewModel.swift
+++ b/Applications/MLXChatExample/ViewModels/ChatViewModel.swift
@@ -26,7 +26,7 @@ class ChatViewModel {
 
     /// Chat history containing system, user, and assistant messages
     var messages: [Message] = [
-        .system("You are a helpful assistant!")
+        .system("You are a helpful assistant.")
     ]
 
     /// Currently selected language model for generation
@@ -44,14 +44,24 @@ class ChatViewModel {
     /// Stores performance metrics from the current generation
     private var generateCompletionInfo: GenerateCompletionInfo?
 
-    /// Current generation speed in tokens per second
-    var tokensPerSecond: Double {
-        generateCompletionInfo?.tokensPerSecond ?? 0
+    /// Current generation speed in tokens per second, if a generation has completed.
+    var tokensPerSecond: Double? {
+        generateCompletionInfo?.tokensPerSecond
+    }
+
+    /// Whether there is any user-visible chat history that can be cleared.
+    var canClearChat: Bool {
+        messages.contains { $0.role != .system }
     }
 
     /// Progress of the current model download, if any
     var modelDownloadProgress: Progress? {
         mlxService.modelDownloadProgress
+    }
+
+    /// Whether a model is currently being initialized into memory.
+    var isLoadingModel: Bool {
+        mlxService.isLoadingModel
     }
 
     /// Most recent error message, if any
@@ -89,7 +99,7 @@ class ChatViewModel {
                 case .info(let info):
                     // Update performance metrics
                     generateCompletionInfo = info
-                case .toolCall(let call):
+                case .toolCall:
                     break
                 }
             }

--- a/Applications/MLXChatExample/ViewModels/ChatViewModel.swift
+++ b/Applications/MLXChatExample/ViewModels/ChatViewModel.swift
@@ -31,7 +31,7 @@ class ChatViewModel {
     /// selected model does not change; when it does, the session is rebuilt and
     /// seeded from this array so the new model continues the conversation.
     var messages: [Message] = [
-        .system("You are a helpful assistant.")
+        .system(MLXService.systemPrompt)
     ]
 
     /// Currently selected language model for generation
@@ -181,7 +181,7 @@ class ChatViewModel {
 
         if options.contains(.chat) {
             generateTask?.cancel()
-            messages = []
+            messages = [.system(MLXService.systemPrompt)]
             mlxService.clearSession()
         }
 

--- a/Applications/MLXChatExample/ViewModels/ChatViewModel.swift
+++ b/Applications/MLXChatExample/ViewModels/ChatViewModel.swift
@@ -24,7 +24,12 @@ class ChatViewModel {
     /// Current user input text
     var prompt: String = ""
 
-    /// Chat history containing system, user, and assistant messages
+    /// Chat history containing system, user, and assistant messages.
+    ///
+    /// `messages` is the on-screen transcript and the source of truth for what
+    /// the model sees. ``MLXService`` reuses its active session as long as the
+    /// selected model does not change; when it does, the session is rebuilt and
+    /// seeded from this array so the new model continues the conversation.
     var messages: [Message] = [
         .system("You are a helpful assistant.")
     ]
@@ -69,7 +74,6 @@ class ChatViewModel {
 
     /// Generates response for the current prompt and media attachments
     func generate() async {
-        // Cancel any existing generation task
         if let existingTask = generateTask {
             existingTask.cancel()
             generateTask = nil
@@ -77,27 +81,52 @@ class ChatViewModel {
 
         isGenerating = true
 
-        // Add user message with any media attachments
-        messages.append(.user(prompt, images: mediaSelection.images, videos: mediaSelection.videos))
-        // Add empty assistant message that will be filled during generation
+        // Capture the current prompt/media so the input can be cleared before the
+        // task starts.
+        let userPrompt = prompt
+        let userImages = mediaSelection.images
+        let userVideos = mediaSelection.videos
+        let model = selectedModel
+
+        // Build the prior conversation (excluding the system prompt, which the
+        // session sets via `instructions`) so `MLXService` can seed a fresh
+        // session if the user just switched models. For follow-up turns on the
+        // same model the service ignores this and reuses its existing session.
+        let history: [Chat.Message] = messages.compactMap { message in
+            switch message.role {
+            case .user:
+                return .user(
+                    message.content,
+                    images: message.images.map { .url($0) },
+                    videos: message.videos.map { .url($0) }
+                )
+            case .assistant:
+                return .assistant(message.content)
+            case .system:
+                return nil
+            }
+        }
+
+        messages.append(.user(userPrompt, images: userImages, videos: userVideos))
         messages.append(.assistant(""))
 
-        // Clear the input after sending
         clear(.prompt)
 
         generateTask = Task {
-            // Process generation chunks and update UI
-            for await generation in try await mlxService.generate(
-                messages: messages, model: selectedModel)
-            {
+            let stream = try await mlxService.generate(
+                history: history,
+                prompt: userPrompt,
+                images: userImages,
+                videos: userVideos,
+                model: model
+            )
+            for try await generation in stream {
                 switch generation {
                 case .chunk(let chunk):
-                    // Append new text to the current assistant message
                     if let assistantMessage = messages.last {
                         assistantMessage.content += chunk
                     }
                 case .info(let info):
-                    // Update performance metrics
                     generateCompletionInfo = info
                 case .toolCall:
                     break
@@ -106,14 +135,12 @@ class ChatViewModel {
         }
 
         do {
-            // Handle task completion and cancellation
             try await withTaskCancellationHandler {
                 try await generateTask?.value
             } onCancel: {
                 Task { @MainActor in
                     generateTask?.cancel()
 
-                    // Mark message as cancelled
                     if let assistantMessage = messages.last {
                         assistantMessage.content += "\n[Cancelled]"
                     }
@@ -153,8 +180,9 @@ class ChatViewModel {
         }
 
         if options.contains(.chat) {
-            messages = []
             generateTask?.cancel()
+            messages = []
+            mlxService.clearSession()
         }
 
         if options.contains(.meta) {

--- a/Applications/MLXChatExample/ViewModels/ChatViewModel.swift
+++ b/Applications/MLXChatExample/ViewModels/ChatViewModel.swift
@@ -144,8 +144,21 @@ class ChatViewModel {
                     if let assistantMessage = messages.last {
                         assistantMessage.content += "\n[Cancelled]"
                     }
+
+                    // Drop the active session so the next turn rebuilds from the
+                    // visible history. ChatSession's KV cache currently holds a
+                    // partial assistant response with no end-of-turn marker;
+                    // continuing on top of it would feed the next model call a
+                    // malformed transcript.
+                    mlxService.clearSession()
                 }
             }
+        } catch is CancellationError {
+            // Expected when the user stops generation, dismisses the view, or
+            // clears the chat mid-generation – not surfaced to the user.
+        } catch let error as URLError where error.code == .cancelled {
+            // Same intent as above, when the cancellation reaches an in-flight
+            // URLSession task (e.g. a model download).
         } catch {
             errorMessage = error.localizedDescription
         }

--- a/Applications/MLXChatExample/Views/MessageView.swift
+++ b/Applications/MLXChatExample/Views/MessageView.swift
@@ -68,9 +68,8 @@ struct MessageView: View {
             }
 
         case .system:
-            // System messages are centered with computer icon
-            Label(message.content, systemImage: "desktopcomputer")
-                .font(.headline)
+            // System messages are centered, prefixed for clarity
+            Text("\(Text("System prompt: ").font(.headline))\(message.content)")
                 .foregroundColor(.secondary)
                 .frame(maxWidth: .infinity, alignment: .center)
         }

--- a/Applications/MLXChatExample/Views/PromptField.swift
+++ b/Applications/MLXChatExample/Views/PromptField.swift
@@ -19,7 +19,10 @@ struct PromptField: View {
             if let mediaButtonAction {
                 Button(action: mediaButtonAction) {
                     Image(systemName: "photo.badge.plus")
+                        .padding(4)
                 }
+                .buttonStyle(.glass)
+                .buttonBorderShape(.circle)
             }
 
             TextField("Prompt", text: $prompt)
@@ -36,8 +39,12 @@ struct PromptField: View {
                     }
                 }
             } label: {
-                Image(systemName: isRunning ? "stop.circle.fill" : "paperplane.fill")
+                Image(systemName: isRunning ? "stop.fill" : "arrow.up")
+                    .fontWeight(.bold)
+                    .padding(4)
             }
+            .buttonStyle(.glassProminent)
+            .buttonBorderShape(.circle)
             .keyboardShortcut(isRunning ? .cancelAction : .defaultAction)
         }
     }

--- a/Applications/MLXChatExample/Views/Toolbar/ChatToolbarView.swift
+++ b/Applications/MLXChatExample/Views/Toolbar/ChatToolbarView.swift
@@ -7,37 +7,68 @@
 
 import SwiftUI
 
-/// Toolbar view for the chat interface that displays error messages, download progress,
+/// Toolbar content for the chat interface that displays error messages, download progress,
 /// generation statistics, and model selection controls.
-struct ChatToolbarView: View {
+struct ChatToolbarView: ToolbarContent {
     /// View model containing the chat state and controls
     @Bindable var vm: ChatViewModel
 
-    var body: some View {
+    var body: some ToolbarContent {
         // Display error message if present
         if let errorMessage = vm.errorMessage {
-            ErrorView(errorMessage: errorMessage)
+            ToolbarItem {
+                ErrorView(errorMessage: errorMessage)
+            }
         }
 
-        // Show download progress for model loading
-        if let progress = vm.modelDownloadProgress, !progress.isFinished {
-            DownloadProgressView(progress: progress)
+        // Show download progress while bytes are flowing from the network
+        if let progress = vm.modelDownloadProgress {
+            ToolbarItem {
+                DownloadProgressView(progress: progress)
+            }
+        } else if vm.isLoadingModel {
+            // Otherwise, show a generic loading indicator while weights are
+            // being initialized into memory.
+            ToolbarItem {
+                ProgressView()
+                    .controlSize(.small)
+                    .help("Loading model")
+            }
+            .sharedBackgroundVisibility(.hidden)
         }
 
-        // Button to clear chat history, displays generation statistics
-        Button {
-            vm.clear([.chat, .meta])
-        } label: {
-            GenerationInfoView(
-                tokensPerSecond: vm.tokensPerSecond
-            )
+        // Generation statistics indicator (only shown after a generation has completed)
+        if let tokensPerSecond = vm.tokensPerSecond {
+            ToolbarItem {
+                GenerationInfoView(
+                    tokensPerSecond: tokensPerSecond
+                )
+            }
+            .sharedBackgroundVisibility(.hidden)
+        }
+
+        ToolbarSpacer(.fixed)
+
+        // Button to clear chat history (only shown when there's something to clear)
+        if vm.canClearChat {
+            ToolbarItem {
+                Button {
+                    vm.clear([.chat, .meta])
+                } label: {
+                    Image(systemName: "trash")
+                }
+                .help("Clear chat")
+                .disabled(vm.isGenerating)
+            }
         }
 
         // Model selection picker
-        Picker("Model", selection: $vm.selectedModel) {
-            ForEach(MLXService.availableModels) { model in
-                Text(model.displayName)
-                    .tag(model)
+        ToolbarItem {
+            Picker("Model", selection: $vm.selectedModel) {
+                ForEach(MLXService.availableModels) { model in
+                    Text(model.displayName)
+                        .tag(model)
+                }
             }
         }
     }

--- a/Applications/MLXChatExample/Views/Toolbar/DownloadProgressView.swift
+++ b/Applications/MLXChatExample/Views/Toolbar/DownloadProgressView.swift
@@ -12,25 +12,35 @@ struct DownloadProgressView: View {
 
     @State private var isShowingDownload = false
 
+    private var bytesText: String {
+        let completed = progress.completedUnitCount.formatted(.byteCount(style: .file))
+        let total = progress.totalUnitCount.formatted(.byteCount(style: .file))
+        return "\(completed) of \(total)"
+    }
+
+    private var percentText: String {
+        progress.fractionCompleted.formatted(.percent.precision(.fractionLength(0)))
+    }
+
     var body: some View {
         Button {
             isShowingDownload = true
         } label: {
-            Image(systemName: "arrow.down.square")
+            Image(systemName: "arrow.down")
                 .foregroundStyle(.tint)
         }
         .popover(isPresented: $isShowingDownload, arrowEdge: .bottom) {
             VStack {
                 ProgressView(value: progress.fractionCompleted) {
                     HStack {
-                        Text(progress.localizedAdditionalDescription)
+                        Text(bytesText)
                             .bold()
                         Spacer()
-                        Text(progress.localizedDescription)
+                        Text(percentText)
                     }
                 }
 
-                Text("The model is downloading")
+                Text("Downloading...")
                     .padding(.horizontal, 32)
             }
             .padding()

--- a/mlx-swift-examples.xcodeproj/project.pbxproj
+++ b/mlx-swift-examples.xcodeproj/project.pbxproj
@@ -1274,13 +1274,13 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MACOSX_DEPLOYMENT_TARGET = 15.0;
+				MACOSX_DEPLOYMENT_TARGET = 26.0;
 				MARKETING_VERSION = 1.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
@@ -1297,7 +1297,7 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2,7";
-				XROS_DEPLOYMENT_TARGET = 2.0;
+				XROS_DEPLOYMENT_TARGET = 26.0;
 			};
 			name = Debug;
 		};
@@ -1335,13 +1335,13 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MACOSX_DEPLOYMENT_TARGET = 15.0;
+				MACOSX_DEPLOYMENT_TARGET = 26.0;
 				MARKETING_VERSION = 1.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
@@ -1358,7 +1358,7 @@
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2,7";
 				VALIDATE_PRODUCT = YES;
-				XROS_DEPLOYMENT_TARGET = 2.0;
+				XROS_DEPLOYMENT_TARGET = 26.0;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
In preparation for a subsequent PR demonstrating the model output parsing and Open Responses streaming enabled by [Swift LM Response Parser](https://github.com/DePasqualeOrg/swift-lm-response-parser), I've fixed many issues in the MLXChatExample app. In order to keep the diff relatively small, I'm deliberately not solving every issue and not covering every edge case, since this is an example app and not meant for production. But these changes represent a significant improvement:

- Fixes for various bugs related to the toolbar buttons
- Download sizes are properly formatted, but download progress is still not shown due to a longstanding bug in Swift Hugging Face (this works properly in my fork, [Swift HF API](https://github.com/DePasqualeOrg/swift-hf-api), which is not used here).
- Chats can be continued after switching models.
- Many other quality-of-life improvements