### PR TITLE
docs: add image-tool README

### DIFF
--- a/ACKNOWLEDGMENTS.md
+++ b/ACKNOWLEDGMENTS.md
@@ -7,6 +7,7 @@
 MLX Swift was developed with contributions from the following individuals:
 
 - [John Mai](https://github.com/johnmai-dev): Added support for multiple models (Qwen2, Starcoder2, InternLM2, Qwen3, Qwen3 MoE, GLM-4, MiMo, BitNet, SmolLM3, LFM2, Baichuan-M1).
+- [Ledio Berdellima](https://github.com/x-n2o): Added image-tool documentation.
 
 <a href="https://github.com/ml-explore/mlx-swift-examples/graphs/contributors">
   <img class="dark-light" src="https://contrib.rocks/image?repo=ml-explore/mlx-swift-examples&anon=0&columns=20&max=100&r=true" />
@@ -14,4 +15,3 @@ MLX Swift was developed with contributions from the following individuals:
 
 
 SOFTWARE.
-

--- a/Tools/image-tool/README.md
+++ b/Tools/image-tool/README.md
@@ -1,0 +1,98 @@
+# image-tool
+
+A command line tool for generating images with the Stable Diffusion example
+library.
+
+See additional documentation:
+
+- [StableDiffusion](../../Libraries/StableDiffusion/README.md) -- reusable
+  Stable Diffusion implementation
+- [StableDiffusionExample](../../Applications/StableDiffusionExample/README.md)
+  -- SwiftUI application using the same library
+
+### Building
+
+Build the `image-tool` scheme in Xcode.
+
+### Running: Xcode
+
+Configure the scheme arguments (Product > Scheme > Edit Scheme > Run >
+Arguments). For example:
+
+```
+sd text \
+    --prompt "purple cow on the moon" \
+    --output /tmp/out.png
+```
+
+Then press <kbd>⌘</kbd>+<kbd>R</kbd> to run.
+
+> Note: the first run downloads model weights from Hugging Face. You may be
+prompted for access to the download location used by the Hugging Face `HubApi`.
+
+### Running: Command Line
+
+Use the `mlx-run` script to run the command line tools:
+
+```
+./mlx-run image-tool sd text --prompt "purple cow on the moon" --output /tmp/out.png
+```
+
+By default this will find and run the tool built in _Release_ configuration.
+Specify `--debug` to find and run the tool built in _Debug_ configuration:
+
+```
+./mlx-run --debug image-tool sd text --prompt "a watercolor robot" --output /tmp/out.png
+```
+
+### Text to Image
+
+The `sd text` command generates one or more images from a prompt and writes an
+image file. The output format is inferred from the `--output` extension and
+defaults to PNG when the extension is not recognized:
+
+```
+./mlx-run image-tool sd text \
+    --model sdxl-turbo \
+    --prompt "a small cabin beside a frozen lake" \
+    --steps 4 \
+    --seed 1234 \
+    --output /tmp/cabin.png
+```
+
+Common generation options include:
+
+- `--prompt` and `--negative-prompt` for text conditioning
+- `--image-count`, `--batch-size`, and `--rows` for image grids
+- `--latent-width` and `--latent-height` for output size, where the final image
+  dimensions are 8x the latent dimensions
+- `--cfg`, `--steps`, and `--seed` for generation behavior
+
+### Image to Image
+
+The `sd image` command uses an input image as the starting point:
+
+```
+./mlx-run image-tool sd image \
+    --input support/test.jpg \
+    --prompt "a studio portrait in watercolor" \
+    --strength 0.75 \
+    --output /tmp/portrait.png
+```
+
+The input image is loaded at dimensions compatible with the model before
+generation. Higher `--strength` values allow the prompt to change more of the
+original image.
+
+### Models and Memory
+
+The default model is `sdxl-turbo`. Use `--model base` for the Stable Diffusion
+2.1 base preset. Pass `--no-float16` to disable float16 conversion or
+`--quantize` to enable quantization.
+
+Memory can be constrained with `--cache-size` and `--memory-size`, both in
+megabytes.
+
+See also:
+
+- [MLX troubleshooting](https://swiftpackageindex.com/ml-explore/mlx-swift/main/documentation/mlx/troubleshooting)


### PR DESCRIPTION
## Proposed changes

Fixes #477.

Adds the missing `Tools/image-tool/README.md` so the top-level `README.md` link for `image-tool` resolves. The new README documents building the scheme, running through Xcode and `mlx-run`, text-to-image usage, image-to-image usage, common generation options, and model/memory options.

Also updates `ACKNOWLEDGMENTS.md` for the documentation contribution.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works (#479)
- [x] I have updated the necessary documentation (if needed)
