### PR TITLE
ci: catch broken markdown links

### DIFF
--- a/.check-links-ignore
+++ b/.check-links-ignore
@@ -3,6 +3,9 @@
 # flagged as broken. One fnmatch glob per line, relative to the repository
 # root. Lines starting with # are comments.
 
+# Test fixtures, not documentation:
+Applications/LLMEval/Models/*
+
 # Moved to the mlx-swift-lm package:
 Libraries/MLXLLM/*
 Libraries/Embedders/*

--- a/.check-links-ignore
+++ b/.check-links-ignore
@@ -1,0 +1,7 @@
+# Link targets that support/check_links.py should not flag as broken.
+# One pattern per line (fnmatch glob), matched against the link target
+# path relative to the repository root. Lines starting with # are comments.
+
+# Moved to the mlx-swift-lm package:
+Libraries/MLXLLM/*
+Libraries/Embedders/*

--- a/.check-links-ignore
+++ b/.check-links-ignore
@@ -1,6 +1,7 @@
-# Link targets that support/check_links.py should not flag as broken.
-# One pattern per line (fnmatch glob), matched against the link target
-# path relative to the repository root. Lines starting with # are comments.
+# Paths that support/check_links.py should skip: markdown files matching
+# a pattern are not scanned, and link targets matching a pattern are not
+# flagged as broken. One fnmatch glob per line, relative to the repository
+# root. Lines starting with # are comments.
 
 # Moved to the mlx-swift-lm package:
 Libraries/MLXLLM/*

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -64,10 +64,10 @@ jobs:
         run: |
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
-      - name: Run style checks
+      - name: Run style and markdown link checks
         shell: sh
         run: |
-          pre-commit run --all || (echo "Style checks failed, please install pre-commit and run pre-commit run --all and push the change"; echo ""; git --no-pager diff; exit 1)
+          pre-commit run --all || (echo "Style or markdown link checks failed, please install pre-commit and run pre-commit run --all and push the change"; echo ""; git --no-pager diff; exit 1)
 
   mac_build_and_test:
     needs: lint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,3 +8,12 @@ repos:
       entry: swift-format format --in-place --configuration .swift-format --recursive .
       require_serial: true
       types: [swift]
+
+- repo: https://github.com/lycheeverse/lychee.git
+  rev: lychee-v0.24.2
+  hooks:
+    - id: lychee
+      args:
+        - --no-progress
+        - --offline
+      types: [markdown]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,11 +9,9 @@ repos:
       require_serial: true
       types: [swift]
 
-- repo: https://github.com/lycheeverse/lychee.git
-  rev: lychee-v0.24.2
-  hooks:
-    - id: lychee
-      args:
-        - --no-progress
-        - --offline
+    - id: check-markdown-links
+      name: check markdown links
+      language: system
+      entry: python3 support/check_links.py
+      require_serial: true
       types: [markdown]

--- a/ACKNOWLEDGMENTS.md
+++ b/ACKNOWLEDGMENTS.md
@@ -7,6 +7,7 @@
 MLX Swift was developed with contributions from the following individuals:
 
 - [John Mai](https://github.com/johnmai-dev): Added support for multiple models (Qwen2, Starcoder2, InternLM2, Qwen3, Qwen3 MoE, GLM-4, MiMo, BitNet, SmolLM3, LFM2, Baichuan-M1).
+- [Ledio Berdellima](https://github.com/x-n2o): Added Markdown link checks in pre-commit/CI.
 
 <a href="https://github.com/ml-explore/mlx-swift-examples/graphs/contributors">
   <img class="dark-light" src="https://contrib.rocks/image?repo=ml-explore/mlx-swift-examples&anon=0&columns=20&max=100&r=true" />

--- a/support/check_links.py
+++ b/support/check_links.py
@@ -74,7 +74,14 @@ def check_file(filepath, directory, ignore_patterns):
     # Match [text](target) but skip external URLs
     link_pattern = re.compile(r'\[([^\]]*)\]\(([^)]+)\)')
 
+    in_code_block = False
     for line_num, line in enumerate(lines, 1):
+        # Skip fenced code blocks -- their contents are not links
+        if line.lstrip().startswith(('```', '~~~')):
+            in_code_block = not in_code_block
+            continue
+        if in_code_block:
+            continue
         for match in link_pattern.finditer(line):
             display = match.group(1)
             target = match.group(2)

--- a/support/check_links.py
+++ b/support/check_links.py
@@ -2,10 +2,10 @@
 """
 Check for broken internal markdown links.
 Scans .md files for links like [text](Something.md) and reports
-any that point to files that don't exist. External links (http,
-https, mailto) and bare anchors are skipped, as are targets that
-resolve outside the repository (they cannot be validated from a
-checkout).
+any that point to files that don't exist. Links with a URL scheme
+or host (http, https, mailto, ...) and bare anchors are skipped,
+as are targets that resolve outside the repository (they cannot
+be validated from a checkout).
 
 Paths listed in .check-links-ignore at the repository root (one
 fnmatch glob per line, relative to the root) are also skipped:
@@ -18,13 +18,17 @@ Usage: python3 check_links.py <directory>
 
 The file form is used by pre-commit, which passes the tracked
 markdown files to check.
+
+Kept in sync between ml-explore/mlx-swift-examples (support/)
+and ml-explore/mlx-swift (tools/).
 """
 
 import fnmatch
+import os
 import re
 import sys
 from pathlib import Path
-from urllib.parse import unquote
+from urllib.parse import unquote, urlsplit
 
 
 # Directories to skip when scanning a directory
@@ -32,9 +36,11 @@ SKIP_DIRS = {'.git', '.build', '.swiftpm', 'vendor', 'node_modules'}
 
 IGNORE_FILE = '.check-links-ignore'
 
+LINK_PATTERN = re.compile(r'\[([^\]]*)\]\(([^)]+)\)')
+
 
 def load_ignore_patterns(base):
-    """Load link-target patterns to skip from .check-links-ignore."""
+    """Load path patterns to skip from .check-links-ignore."""
     ignore_file = base / IGNORE_FILE
     if not ignore_file.is_file():
         return []
@@ -48,72 +54,56 @@ def load_ignore_patterns(base):
 
 def is_ignored(path, base, ignore_patterns):
     """True if path (relative to base) matches an ignore pattern."""
-    try:
-        rel = path.relative_to(base)
-    except ValueError:
+    if not path.is_relative_to(base):
         return False
-    return any(fnmatch.fnmatch(str(rel), p) for p in ignore_patterns)
+    rel = str(path.relative_to(base))
+    return any(fnmatch.fnmatch(rel, p) for p in ignore_patterns)
 
 
 def find_all_md_files(directory):
     """Build a set of all .md file paths under the directory."""
     md_files = set()
-    for filepath in directory.rglob('*.md'):
-        if any(part in SKIP_DIRS for part in filepath.parts):
-            continue
-        md_files.add(filepath)
+    for dirpath, dirnames, filenames in os.walk(directory):
+        dirnames[:] = [d for d in dirnames if d not in SKIP_DIRS]
+        md_files.update(
+            Path(dirpath) / name for name in filenames if name.endswith('.md'))
     return md_files
 
 
 def check_file(filepath, directory, ignore_patterns):
-    """Check all internal links in a file. Returns list of (source, line_num, link_text, target) tuples."""
+    """Check all internal links in a file. Returns a list of
+    (line_num, link_text, target) tuples for broken links."""
     broken = []
-    with open(filepath, 'r', encoding='utf-8') as f:
-        lines = f.readlines()
-
-    # Match [text](target) but skip external URLs
-    link_pattern = re.compile(r'\[([^\]]*)\]\(([^)]+)\)')
-
     in_code_block = False
-    for line_num, line in enumerate(lines, 1):
-        # Skip fenced code blocks -- their contents are not links
-        if line.lstrip().startswith(('```', '~~~')):
-            in_code_block = not in_code_block
-            continue
-        if in_code_block:
-            continue
-        for match in link_pattern.finditer(line):
-            display = match.group(1)
-            target = match.group(2)
-
-            # Skip external links
-            if target.startswith(('http://', 'https://', 'mailto:', '#')):
+    with open(filepath, 'r', encoding='utf-8') as f:
+        for line_num, line in enumerate(f, 1):
+            # Skip fenced code blocks -- their contents are not links
+            if line.lstrip().startswith(('```', '~~~')):
+                in_code_block = not in_code_block
                 continue
-
-            # Strip anchor fragments
-            target = target.split('#')[0]
-            if not target:
+            if in_code_block:
                 continue
+            for match in LINK_PATTERN.finditer(line):
+                display = match.group(1)
+                target = urlsplit(match.group(2))
 
-            # URL-decode (e.g. %20 -> space)
-            target = unquote(target)
+                # Skip external links and bare anchors
+                if target.scheme or target.netloc or not target.path:
+                    continue
 
-            # Resolve relative to the file's directory
-            target_path = (filepath.parent / target).resolve()
+                # URL-decode (e.g. %20 -> space) and resolve relative
+                # to the file's directory
+                target_path = (filepath.parent / unquote(target.path)).resolve()
 
-            # Targets outside the repository cannot be validated here
-            if not target_path.is_relative_to(directory):
-                continue
+                # Targets outside the repository cannot be validated here
+                if not target_path.is_relative_to(directory):
+                    continue
 
-            if is_ignored(target_path, directory, ignore_patterns):
-                continue
+                if is_ignored(target_path, directory, ignore_patterns):
+                    continue
 
-            if not target_path.exists():
-                try:
-                    rel_source = filepath.relative_to(directory)
-                except ValueError:
-                    rel_source = filepath
-                broken.append((rel_source, line_num, display, target))
+                if not target_path.exists():
+                    broken.append((line_num, display, target.path))
 
     return broken
 
@@ -132,27 +122,27 @@ def main():
 
     ignore_patterns = load_ignore_patterns(directory)
 
-    all_broken = []
+    by_file = {}
     for filepath in sorted(md_files):
         if is_ignored(filepath, directory, ignore_patterns):
             continue
-        all_broken.extend(check_file(filepath, directory, ignore_patterns))
+        broken = check_file(filepath, directory, ignore_patterns)
+        if broken:
+            rel = (filepath.relative_to(directory)
+                   if filepath.is_relative_to(directory) else filepath)
+            by_file[rel] = broken
 
-    if not all_broken:
+    if not by_file:
         print("No broken links found.")
         sys.exit(0)
 
-    # Group by source file
-    by_file = {}
-    for source, line_num, display, target in all_broken:
-        by_file.setdefault(source, []).append((line_num, display, target))
-
-    for source in sorted(by_file):
+    for source, broken in by_file.items():
         print(f"\n{source}:")
-        for line_num, display, target in by_file[source]:
+        for line_num, display, target in broken:
             print(f"  line {line_num}: [{display}]({target}) -> NOT FOUND")
 
-    print(f"\nTotal: {len(all_broken)} broken link(s) in {len(by_file)} file(s)")
+    total = sum(len(broken) for broken in by_file.values())
+    print(f"\nTotal: {total} broken link(s) in {len(by_file)} file(s)")
     sys.exit(1)
 
 

--- a/support/check_links.py
+++ b/support/check_links.py
@@ -3,7 +3,12 @@
 Check for broken internal markdown links.
 Scans .md files for links like [text](Something.md) and reports
 any that point to files that don't exist. External links (http,
-https, mailto) and bare anchors are skipped.
+https, mailto) and bare anchors are skipped, as are targets that
+resolve outside the repository (they cannot be validated from a
+checkout).
+
+Targets listed in .check-links-ignore at the repository root (one
+fnmatch glob per line, relative to the root) are also skipped.
 
 Usage: python3 check_links.py <directory>
        python3 check_links.py <file.md> [<file.md> ...]
@@ -12,6 +17,7 @@ The file form is used by pre-commit, which passes the tracked
 markdown files to check.
 """
 
+import fnmatch
 import re
 import sys
 from pathlib import Path
@@ -20,6 +26,21 @@ from urllib.parse import unquote
 
 # Directories to skip when scanning a directory
 SKIP_DIRS = {'.git', '.build', '.swiftpm', 'vendor', 'node_modules'}
+
+IGNORE_FILE = '.check-links-ignore'
+
+
+def load_ignore_patterns(base):
+    """Load link-target patterns to skip from .check-links-ignore."""
+    ignore_file = base / IGNORE_FILE
+    if not ignore_file.is_file():
+        return []
+    patterns = []
+    for line in ignore_file.read_text(encoding='utf-8').splitlines():
+        line = line.strip()
+        if line and not line.startswith('#'):
+            patterns.append(line)
+    return patterns
 
 
 def find_all_md_files(directory):
@@ -32,7 +53,7 @@ def find_all_md_files(directory):
     return md_files
 
 
-def check_file(filepath, directory):
+def check_file(filepath, directory, ignore_patterns):
     """Check all internal links in a file. Returns list of (source, line_num, link_text, target) tuples."""
     broken = []
     with open(filepath, 'r', encoding='utf-8') as f:
@@ -61,6 +82,15 @@ def check_file(filepath, directory):
             # Resolve relative to the file's directory
             target_path = (filepath.parent / target).resolve()
 
+            # Targets outside the repository cannot be validated here
+            try:
+                rel_target = target_path.relative_to(directory)
+            except ValueError:
+                continue
+
+            if any(fnmatch.fnmatch(str(rel_target), p) for p in ignore_patterns):
+                continue
+
             if not target_path.exists():
                 try:
                     rel_source = filepath.relative_to(directory)
@@ -83,9 +113,11 @@ def main():
         print("Usage: python3 check_links.py <directory or markdown files>")
         sys.exit(1)
 
+    ignore_patterns = load_ignore_patterns(directory)
+
     all_broken = []
     for filepath in sorted(md_files):
-        all_broken.extend(check_file(filepath, directory))
+        all_broken.extend(check_file(filepath, directory, ignore_patterns))
 
     if not all_broken:
         print("No broken links found.")

--- a/support/check_links.py
+++ b/support/check_links.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""
+Check for broken internal markdown links.
+Scans .md files for links like [text](Something.md) and reports
+any that point to files that don't exist. External links (http,
+https, mailto) and bare anchors are skipped.
+
+Usage: python3 check_links.py <directory>
+       python3 check_links.py <file.md> [<file.md> ...]
+
+The file form is used by pre-commit, which passes the tracked
+markdown files to check.
+"""
+
+import re
+import sys
+from pathlib import Path
+from urllib.parse import unquote
+
+
+# Directories to skip when scanning a directory
+SKIP_DIRS = {'.git', '.build', '.swiftpm', 'vendor', 'node_modules'}
+
+
+def find_all_md_files(directory):
+    """Build a set of all .md file paths under the directory."""
+    md_files = set()
+    for filepath in directory.rglob('*.md'):
+        if any(part in SKIP_DIRS for part in filepath.parts):
+            continue
+        md_files.add(filepath)
+    return md_files
+
+
+def check_file(filepath, directory):
+    """Check all internal links in a file. Returns list of (source, line_num, link_text, target) tuples."""
+    broken = []
+    with open(filepath, 'r', encoding='utf-8') as f:
+        lines = f.readlines()
+
+    # Match [text](target) but skip external URLs
+    link_pattern = re.compile(r'\[([^\]]*)\]\(([^)]+)\)')
+
+    for line_num, line in enumerate(lines, 1):
+        for match in link_pattern.finditer(line):
+            display = match.group(1)
+            target = match.group(2)
+
+            # Skip external links
+            if target.startswith(('http://', 'https://', 'mailto:', '#')):
+                continue
+
+            # Strip anchor fragments
+            target = target.split('#')[0]
+            if not target:
+                continue
+
+            # URL-decode (e.g. %20 -> space)
+            target = unquote(target)
+
+            # Resolve relative to the file's directory
+            target_path = (filepath.parent / target).resolve()
+
+            if not target_path.exists():
+                try:
+                    rel_source = filepath.relative_to(directory)
+                except ValueError:
+                    rel_source = filepath
+                broken.append((rel_source, line_num, display, target))
+
+    return broken
+
+
+def main():
+    args = sys.argv[1:]
+    if len(args) == 1 and Path(args[0]).is_dir():
+        directory = Path(args[0]).resolve()
+        md_files = find_all_md_files(directory)
+    elif args:
+        directory = Path.cwd()
+        md_files = {Path(arg).resolve() for arg in args}
+    else:
+        print("Usage: python3 check_links.py <directory or markdown files>")
+        sys.exit(1)
+
+    all_broken = []
+    for filepath in sorted(md_files):
+        all_broken.extend(check_file(filepath, directory))
+
+    if not all_broken:
+        print("No broken links found.")
+        sys.exit(0)
+
+    # Group by source file
+    by_file = {}
+    for source, line_num, display, target in all_broken:
+        by_file.setdefault(source, []).append((line_num, display, target))
+
+    for source in sorted(by_file):
+        print(f"\n{source}:")
+        for line_num, display, target in by_file[source]:
+            print(f"  line {line_num}: [{display}]({target}) -> NOT FOUND")
+
+    print(f"\nTotal: {len(all_broken)} broken link(s) in {len(by_file)} file(s)")
+    sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/support/check_links.py
+++ b/support/check_links.py
@@ -7,8 +7,11 @@ https, mailto) and bare anchors are skipped, as are targets that
 resolve outside the repository (they cannot be validated from a
 checkout).
 
-Targets listed in .check-links-ignore at the repository root (one
-fnmatch glob per line, relative to the root) are also skipped.
+Paths listed in .check-links-ignore at the repository root (one
+fnmatch glob per line, relative to the root) are also skipped:
+markdown files matching a pattern are not scanned (e.g. vendored
+third-party docs), and link targets matching a pattern are not
+flagged as broken (e.g. targets that moved to another repository).
 
 Usage: python3 check_links.py <directory>
        python3 check_links.py <file.md> [<file.md> ...]
@@ -41,6 +44,15 @@ def load_ignore_patterns(base):
         if line and not line.startswith('#'):
             patterns.append(line)
     return patterns
+
+
+def is_ignored(path, base, ignore_patterns):
+    """True if path (relative to base) matches an ignore pattern."""
+    try:
+        rel = path.relative_to(base)
+    except ValueError:
+        return False
+    return any(fnmatch.fnmatch(str(rel), p) for p in ignore_patterns)
 
 
 def find_all_md_files(directory):
@@ -83,12 +95,10 @@ def check_file(filepath, directory, ignore_patterns):
             target_path = (filepath.parent / target).resolve()
 
             # Targets outside the repository cannot be validated here
-            try:
-                rel_target = target_path.relative_to(directory)
-            except ValueError:
+            if not target_path.is_relative_to(directory):
                 continue
 
-            if any(fnmatch.fnmatch(str(rel_target), p) for p in ignore_patterns):
+            if is_ignored(target_path, directory, ignore_patterns):
                 continue
 
             if not target_path.exists():
@@ -117,6 +127,8 @@ def main():
 
     all_broken = []
     for filepath in sorted(md_files):
+        if is_ignored(filepath, directory, ignore_patterns):
+            continue
         all_broken.extend(check_file(filepath, directory, ignore_patterns))
 
     if not all_broken:


### PR DESCRIPTION
## Proposed changes

Adds a markdown link check to the existing pre-commit workflow so repository-local links are validated locally and in pull request CI. Per review feedback, this now uses a small local script (`support/check_links.py`, adapted from the one suggested in review) instead of a third-party dependency.

- pre-commit passes the tracked markdown files to the script; links with a URL scheme or host are skipped — matching the previous offline lychee behavior without the extra dependency. The script also supports a manual whole-tree scan: `python3 support/check_links.py .`
- Links inside fenced code blocks are ignored.
- Link targets that no longer live in this repository are not treated as broken: targets resolving outside the checkout are skipped, and a `.check-links-ignore` blocklist (fnmatch globs, repo-root relative) covers prompt fixtures (`Applications/LLMEval/Models/*`) and the paths that moved to the [mlx-swift-lm](https://github.com/ml-explore/mlx-swift-lm) package (`Libraries/MLXLLM/*`, `Libraries/Embedders/*`).
- The same script is proposed for mlx-swift in ml-explore/mlx-swift#403; the two copies are kept in sync.

This helps prevent broken repository links like the missing `Tools/image-tool/README.md` entry reported in #477 (fixed by #481).

The one genuinely broken in-repo link surfaced by the check is tracked separately:

- #484 — `Tools/mnist-tool/README.md` → `Libraries/MNIST/README.md`, renamed to `MLXMNIST` in #151 (fixed by #485)

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)

Local run — the check correctly flags the link tracked in #484; once #485 lands this goes green:

```
❯ pre-commit run --all
swift-format.............................................................Passed
check markdown links.....................................................Failed
- hook id: check-markdown-links
- exit code: 1

Tools/mnist-tool/README.md:
  line 3: [MNIST README.md](../../Libraries/MNIST/README.md) -> NOT FOUND

Total: 1 broken link(s) in 1 file(s)
```
