### PR TITLE
docs(mnist-tool): fix link to renamed MLXMNIST README

### DIFF
--- a/Tools/mnist-tool/README.md
+++ b/Tools/mnist-tool/README.md
@@ -1,6 +1,6 @@
 #  mnist-tool
 
-See the [MNIST README.md](../../Libraries/MNIST/README.md).
+See the [MLXMNIST README.md](../../Libraries/MLXMNIST/README.md).
 
 ### Building
 


### PR DESCRIPTION
## Proposed changes

Fixes #484.

`Tools/mnist-tool/README.md` links to `Libraries/MNIST/README.md`, which 404s — the library was renamed to `Libraries/MLXMNIST` in #151 and the link was never updated. This updates the link to the renamed path.

Surfaced by the markdown link check proposed in #479.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
