### PR TITLE
docs(embedder-tool): fix link to relocated MLXEmbedders library

### DIFF
--- a/Tools/embedder-tool/README.md
+++ b/Tools/embedder-tool/README.md
@@ -2,7 +2,7 @@
 
 See additional documentation for supporting libraries:
 
-- [Embedders](../../Libraries/Embedders/README.md)
+- [MLXEmbedders](https://github.com/ml-explore/mlx-swift-lm/tree/main/Libraries/MLXEmbedders)
 
 ### Building
 


### PR DESCRIPTION
## Proposed changes

Fixes #483.

`Tools/embedder-tool/README.md` links to `Libraries/Embedders/README.md`, which 404s — the embedders library moved to the [mlx-swift-lm](https://github.com/ml-explore/mlx-swift-lm) package as `MLXEmbedders`. This updates the link to point there, matching the form already used in `Applications/MLXChatExample/README.md`.

Surfaced by the markdown link check proposed in #479.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
