### PR TITLE
use more succint #huggingFaceLoadModelContainer macro in example codes

### DIFF
--- a/Applications/LLMBasic/ChatModel.swift
+++ b/Applications/LLMBasic/ChatModel.swift
@@ -43,9 +43,7 @@ private let generateParameters = GenerateParameters(temperature: 0.5)
         case .idle:
             let task = Task {
                 // download and report progress
-                try await LLMModelFactory.shared.loadContainer(
-                    from: #hubDownloader(),
-                    using: #huggingFaceTokenizerLoader(),
+                try await #huggingFaceLoadModelContainer(
                     configuration: modelConfiguration
                 ) { value in
                     Task { @MainActor in

--- a/Applications/LoRATrainingExample/ContentView.swift
+++ b/Applications/LoRATrainingExample/ContentView.swift
@@ -143,12 +143,7 @@ class LoRAEvaluator {
                 progress = .init(title: "Loading \(name)", current: 0, limit: 1)
             }
 
-            let downloader = #hubDownloader()
-            let loader = #huggingFaceTokenizerLoader()
-
-            let modelContainer = try await LLMModelFactory.shared.loadContainer(
-                from: downloader,
-                using: loader,
+            let modelContainer = try await #huggingFaceLoadModelContainer(
                 configuration: modelConfiguration
             ) {
                 progress in


### PR DESCRIPTION
## Proposed changes

Remove the default `#hubDownloader` and `#huggingFaceTokenizerLoader` macros, replacing them with the more succinct `#huggingFaceLoadModelContainer` macro where relevant.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
