### PR TITLE
Add MuseGlimmerDemo, a macOS app for the 30B Muse-Glimmer VLM

### DIFF
--- a/Applications/MuseGlimmerDemo/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/Applications/MuseGlimmerDemo/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Applications/MuseGlimmerDemo/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Applications/MuseGlimmerDemo/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,85 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "tinted"
+        }
+      ],
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "16x16"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "16x16"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "32x32"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "32x32"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "128x128"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "128x128"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "256x256"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "256x256"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "512x512"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "512x512"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Applications/MuseGlimmerDemo/Assets.xcassets/Contents.json
+++ b/Applications/MuseGlimmerDemo/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Applications/MuseGlimmerDemo/ContentView.swift
+++ b/Applications/MuseGlimmerDemo/ContentView.swift
@@ -1,0 +1,446 @@
+import AppKit
+import Foundation
+import MLX
+import MLXLMCommon
+import SwiftUI
+import UniformTypeIdentifiers
+
+/// File scope rather than a `View` static: it is read from a Sendable closure in
+/// the paste handler, which cannot touch main-actor-isolated state.
+private let imageTypes: Set<String> = [
+    "png", "jpg", "jpeg", "heic", "heif", "tiff", "tif", "webp", "gif", "bmp",
+]
+
+struct ContentView: View {
+    @State private var service = MuseGlimmerService()
+
+    @State private var prompt = "Describe this image."
+    @State private var droppedImage: URL?
+    @State private var thumbnail: NSImage?
+    @State private var isTargeted = false
+
+    @State private var output = ""
+    @State private var isGenerating = false
+    @State private var stats: String?
+    @State private var errorMessage: String?
+    @State private var maxTokens = 400
+
+    /// Well below the checkpoint's 4096. At 4096 a large image costs ~30 s before
+    /// the first token, almost all of it prefilling the ~4100 prompt tokens the
+    /// image expands into; 1024 lands around 2-3 s with little visible loss.
+    @State private var maxImageTokens = 1024
+    @State private var generateTask: Task<Void, Never>?
+
+    /// Where we are between "Send" and the first token. The wait is long and
+    /// entirely front-loaded, so it needs to be visible.
+    enum Phase: Equatable {
+        case idle
+        case preparing
+        case encodingImage
+        case prefilling
+        /// Prefill is done but nothing is streaming yet. The framework drops
+        /// reasoning from the public `Generation` stream, and Muse-Glimmer reasons
+        /// at length before answering, so this window is silent — several seconds
+        /// on top of prefill with no output at all unless it is named.
+        case reasoning
+        case streaming
+    }
+
+    @State private var phase: Phase = .idle
+    @State private var promptComposition: (total: Int, image: Int)?
+    @State private var prefill: (processed: Int, total: Int)?
+    @State private var timeToFirstToken: TimeInterval?
+
+    var body: some View {
+        VStack(spacing: 12) {
+            header
+
+            HSplitView {
+                imageWell
+                    .frame(minWidth: 240, idealWidth: 300)
+                outputPane
+                    .frame(minWidth: 340)
+            }
+
+            promptBar
+        }
+        .padding(14)
+        .task {
+            // An image path passed on the command line preloads the well, which
+            // makes the drop-to-describe flow scriptable for smoke tests.
+            if let path = CommandLine.arguments.dropFirst().first,
+                imageTypes.contains((path as NSString).pathExtension.lowercased())
+            {
+                setImage(URL(fileURLWithPath: path))
+            }
+            await service.load()
+        }
+        .onDisappear { generateTask?.cancel() }
+    }
+
+    // MARK: - Header
+
+    @ViewBuilder
+    private var header: some View {
+        HStack(spacing: 10) {
+            Text("Muse-Glimmer 30B")
+                .font(.headline)
+            Text("on-device")
+                .font(.caption)
+                .padding(.horizontal, 6)
+                .padding(.vertical, 2)
+                .background(.quaternary, in: Capsule())
+
+            Spacer()
+
+            switch service.loadState {
+            case .idle:
+                Text("Idle").foregroundStyle(.secondary).font(.caption)
+            case .loading(let progress):
+                HStack(spacing: 6) {
+                    if let progress, progress.totalUnitCount > 0 {
+                        ProgressView(value: progress.fractionCompleted)
+                            .frame(width: 120)
+                        Text("\(Int(progress.fractionCompleted * 100))%")
+                            .font(.caption.monospacedDigit())
+                    } else {
+                        ProgressView().controlSize(.small)
+                        Text("Loading…").font(.caption)
+                    }
+                }
+                .foregroundStyle(.secondary)
+            case .ready:
+                Label("Ready", systemImage: "checkmark.circle.fill")
+                    .font(.caption)
+                    .foregroundStyle(.green)
+            case .failed(let message):
+                Label("Load failed", systemImage: "exclamationmark.triangle.fill")
+                    .font(.caption)
+                    .foregroundStyle(.red)
+                    .help(message)
+            }
+        }
+    }
+
+    // MARK: - Image well
+
+    @ViewBuilder
+    private var imageWell: some View {
+        VStack(spacing: 8) {
+            ZStack {
+                RoundedRectangle(cornerRadius: 10)
+                    .strokeBorder(
+                        isTargeted ? Color.accentColor : Color.secondary.opacity(0.4),
+                        style: StrokeStyle(lineWidth: isTargeted ? 2 : 1, dash: [6, 4])
+                    )
+                    .background(
+                        RoundedRectangle(cornerRadius: 10)
+                            .fill(isTargeted ? Color.accentColor.opacity(0.08) : Color.clear))
+
+                if let thumbnail {
+                    Image(nsImage: thumbnail)
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .padding(6)
+                } else {
+                    VStack(spacing: 6) {
+                        Image(systemName: "photo.on.rectangle.angled")
+                            .font(.system(size: 28))
+                            .foregroundStyle(.secondary)
+                        Text("Drop an image").font(.callout).foregroundStyle(.secondary)
+                        Text("or click to choose").font(.caption2).foregroundStyle(.tertiary)
+                    }
+                }
+            }
+            .frame(minHeight: 240)
+            .contentShape(Rectangle())
+            .onTapGesture(perform: chooseImage)
+            .dropDestination(for: URL.self) { urls, _ in
+                guard
+                    let url = urls.first(where: {
+                        imageTypes.contains($0.pathExtension.lowercased())
+                    })
+                else { return false }
+                setImage(url)
+                return true
+            } isTargeted: {
+                isTargeted = $0
+            }
+            .onPasteCommand(of: [.fileURL]) { providers in
+                for provider in providers {
+                    _ = provider.loadObject(ofClass: URL.self) { url, _ in
+                        guard let url,
+                            imageTypes.contains(url.pathExtension.lowercased())
+                        else { return }
+                        Task { @MainActor in setImage(url) }
+                    }
+                }
+            }
+
+            if let droppedImage {
+                HStack(spacing: 6) {
+                    Text(droppedImage.lastPathComponent)
+                        .font(.caption)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                        .layoutPriority(1)
+                    Button("Clear") {
+                        self.droppedImage = nil
+                        self.thumbnail = nil
+                    }
+                    .buttonStyle(.link)
+                    .font(.caption)
+                    .fixedSize()
+                }
+            }
+        }
+    }
+
+    // MARK: - Output
+
+    /// Explains the pre-token wait, which is almost all of the perceived latency.
+    ///
+    /// An image expands into up to 4096 prompt tokens, and prefill runs at roughly
+    /// 200 tokens/s through the 52-layer text stack, so a large image can mean
+    /// tens of seconds before anything appears. Showing the token count alongside
+    /// the progress bar makes the cost legible rather than mysterious.
+    @ViewBuilder
+    private var statusStrip: some View {
+        if phase != .idle || timeToFirstToken != nil {
+            VStack(alignment: .leading, spacing: 4) {
+                HStack(spacing: 6) {
+                    switch phase {
+                    case .idle:
+                        Image(systemName: "checkmark.circle.fill")
+                            .foregroundStyle(.green)
+                        Text("Done")
+                    case .preparing:
+                        ProgressView().controlSize(.small)
+                        Text("Preparing prompt…")
+                    case .encodingImage:
+                        ProgressView().controlSize(.small)
+                        Text("Resizing and encoding image…")
+                    case .prefilling:
+                        ProgressView().controlSize(.small)
+                        if let prefill, prefill.total > 0 {
+                            Text("Prefilling \(prefill.processed) / \(prefill.total) tokens")
+                        } else {
+                            Text("Prefilling prompt…")
+                        }
+                    case .reasoning:
+                        ProgressView().controlSize(.small)
+                        Text("Reasoning (not streamed by the framework)…")
+                    case .streaming:
+                        Image(systemName: "text.cursor")
+                        Text("Generating")
+                    }
+
+                    Spacer()
+
+                    if let timeToFirstToken {
+                        Text(String(format: "first token %.1fs", timeToFirstToken))
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .font(.caption)
+
+                if phase == .prefilling, let prefill, prefill.total > 0 {
+                    ProgressView(
+                        value: Double(prefill.processed), total: Double(prefill.total))
+                }
+
+                if let promptComposition {
+                    Text(
+                        promptComposition.image > 0
+                            ? "\(promptComposition.total) prompt tokens "
+                                + "(\(promptComposition.image) from the image)"
+                            : "\(promptComposition.total) prompt tokens"
+                    )
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+                }
+            }
+            .padding(.horizontal, 2)
+        }
+    }
+
+    @ViewBuilder
+    private var outputPane: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            statusStrip
+
+            ScrollView {
+                // The framework strips the protocol's control tokens and withholds
+                // reasoning, so what arrives here is the answer text alone.
+                Text(output.isEmpty ? "Response will stream here." : output)
+                    .font(.body)
+                    .foregroundStyle(output.isEmpty ? .tertiary : .primary)
+                    .textSelection(.enabled)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(8)
+            }
+            .background(.quinary, in: RoundedRectangle(cornerRadius: 8))
+
+            if let errorMessage {
+                Text(errorMessage)
+                    .font(.caption)
+                    .foregroundStyle(.red)
+                    .textSelection(.enabled)
+            }
+            if let stats {
+                Text(stats)
+                    .font(.caption.monospacedDigit())
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    // MARK: - Prompt bar
+
+    @ViewBuilder
+    private var promptBar: some View {
+        VStack(spacing: 8) {
+            HStack(spacing: 8) {
+                TextField("Prompt", text: $prompt, axis: .vertical)
+                    .lineLimit(1 ... 3)
+                    .textFieldStyle(.roundedBorder)
+                    .onSubmit(start)
+
+                if isGenerating {
+                    Button("Stop") {
+                        generateTask?.cancel()
+                    }
+                    .keyboardShortcut(".", modifiers: .command)
+                } else {
+                    Button("Send", action: start)
+                        .keyboardShortcut(.return, modifiers: .command)
+                        .disabled(!isReady || prompt.trimmingCharacters(in: .whitespaces).isEmpty)
+                }
+            }
+
+            HStack(spacing: 16) {
+                HStack(spacing: 6) {
+                    Text("Max tokens")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Slider(
+                        value: .init(
+                            get: { Double(maxTokens) }, set: { maxTokens = Int($0) }),
+                        in: 64 ... 2048, step: 64)
+                    Text("\(maxTokens)")
+                        .font(.caption.monospacedDigit())
+                        .foregroundStyle(.secondary)
+                        .frame(width: 42, alignment: .trailing)
+                }
+
+                HStack(spacing: 6) {
+                    Text("Image budget")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Slider(
+                        value: .init(
+                            get: { Double(maxImageTokens) },
+                            set: { maxImageTokens = Int($0) }),
+                        in: 256 ... 4096, step: 256)
+                    Text("\(maxImageTokens)")
+                        .font(.caption.monospacedDigit())
+                        .foregroundStyle(.secondary)
+                        .frame(width: 42, alignment: .trailing)
+                }
+                .help(
+                    "Caps how many tokens the image becomes. The dominant cost "
+                        + "before the first token.")
+            }
+        }
+    }
+
+    private var isReady: Bool {
+        if case .ready = service.loadState { return true }
+        return false
+    }
+
+    // MARK: - Actions
+
+    private func chooseImage() {
+        let panel = NSOpenPanel()
+        panel.allowsMultipleSelection = false
+        panel.canChooseDirectories = false
+        panel.allowedContentTypes = [.image]
+        if panel.runModal() == .OK, let url = panel.url {
+            setImage(url)
+        }
+    }
+
+    private func setImage(_ url: URL) {
+        droppedImage = url
+        thumbnail = NSImage(contentsOf: url)
+    }
+
+    private func start() {
+        guard isReady, !isGenerating else { return }
+        let prompt = prompt
+        let image = droppedImage
+        let maxTokens = maxTokens
+        let maxImageTokens = maxImageTokens
+
+        output = ""
+        stats = nil
+        errorMessage = nil
+        isGenerating = true
+        phase = image == nil ? .preparing : .encodingImage
+        promptComposition = nil
+        prefill = nil
+        timeToFirstToken = nil
+        let started = Date()
+
+        generateTask = Task {
+            do {
+                for await event in try service.generate(
+                    prompt: prompt, image: image, maxTokens: maxTokens,
+                    maxImageTokens: maxImageTokens)
+                {
+                    if Task.isCancelled { break }
+                    switch event {
+                    case .prompt(let total, let imageTokens):
+                        await MainActor.run {
+                            promptComposition = (total, imageTokens)
+                            phase = .prefilling
+                        }
+                    case .prefill(let processed, let total):
+                        await MainActor.run {
+                            prefill = (processed, total)
+                            // A terminal (total, total) means prefill is finished;
+                            // what follows is reasoning we never see.
+                            phase = processed >= total ? .reasoning : .prefilling
+                        }
+                    case .chunk(let text):
+                        await MainActor.run {
+                            if timeToFirstToken == nil {
+                                timeToFirstToken = Date().timeIntervalSince(started)
+                            }
+                            phase = .streaming
+                            output += text
+                        }
+                    case .completed(let promptTime, let tokensPerSecond, let peakBytes):
+                        await MainActor.run {
+                            stats = String(
+                                format: "%.1f tok/s · prefill %.1fs · %.2f GB peak",
+                                tokensPerSecond, promptTime,
+                                Double(peakBytes) / 1_073_741_824)
+                        }
+                    case .failed(let message):
+                        await MainActor.run { errorMessage = message }
+                    }
+                }
+            } catch {
+                await MainActor.run { errorMessage = String(describing: error) }
+            }
+
+            await MainActor.run {
+                phase = .idle
+                prefill = nil
+                isGenerating = false
+            }
+        }
+    }
+}

--- a/Applications/MuseGlimmerDemo/MuseGlimmerDemo.entitlements
+++ b/Applications/MuseGlimmerDemo/MuseGlimmerDemo.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.kernel.increased-memory-limit</key>
+	<true/>
+</dict>
+</plist>

--- a/Applications/MuseGlimmerDemo/MuseGlimmerDemoApp.swift
+++ b/Applications/MuseGlimmerDemo/MuseGlimmerDemoApp.swift
@@ -1,0 +1,11 @@
+import SwiftUI
+
+@main
+struct MuseGlimmerDemoApp: App {
+    var body: some Scene {
+        WindowGroup("Muse-Glimmer") {
+            ContentView()
+                .frame(minWidth: 760, minHeight: 560)
+        }
+    }
+}

--- a/Applications/MuseGlimmerDemo/MuseGlimmerService.swift
+++ b/Applications/MuseGlimmerDemo/MuseGlimmerService.swift
@@ -1,0 +1,170 @@
+import Foundation
+import HuggingFace
+import MLX
+import MLXHuggingFace
+import MLXLMCommon
+import MLXVLM
+import Tokenizers
+
+/// What the model is doing between "Send" and the first token.
+///
+/// Worth surfacing because the wait is long and entirely front-loaded: an image
+/// expands into up to 4096 prompt tokens, and every one of them has to be
+/// prefilled through the 52-layer text stack at roughly 200 tokens/s before any
+/// output can appear. Without this the app looks hung.
+enum GenerationEvent: Sendable {
+    /// Prompt has been tokenized; `image` of `total` tokens came from the image.
+    case prompt(total: Int, image: Int)
+    /// `processed` of `total` prompt positions submitted to the GPU.
+    case prefill(processed: Int, total: Int)
+    case chunk(String)
+    case completed(promptTime: TimeInterval, tokensPerSecond: Double, peakBytes: Int)
+    case failed(String)
+}
+
+/// Loads Muse-Glimmer once and streams generations from it.
+///
+/// Everything after the initial download runs on-device; there are no network
+/// calls on the generate path.
+@MainActor
+@Observable
+final class MuseGlimmerService {
+
+    /// Roughly 20 GB resident for the 4-bit weights, of which ~3.7 GB is the
+    /// unquantized bf16 vision tower.
+    static let configuration = VLMRegistry.museGlimmer30B4bit
+
+    enum LoadState {
+        case idle
+        case loading(Progress?)
+        case ready
+        case failed(String)
+    }
+
+    private(set) var loadState: LoadState = .idle
+
+    private var container: ModelContainer?
+
+    /// Tunes the allocator for a ~20 GB resident model rather than the ~2 GB the
+    /// example apps assume. The default 20 MB buffer cache thrashes badly at this
+    /// size, since a single image encode churns multi-hundred-MB activations.
+    static func configureMemory() {
+        Memory.cacheLimit = 2 * 1024 * 1024 * 1024
+        Memory.memoryLimit = 48 * 1024 * 1024 * 1024
+    }
+
+    func load() async {
+        if case .ready = loadState { return }
+        if case .loading = loadState { return }
+
+        Self.configureMemory()
+        loadState = .loading(nil)
+        do {
+            let container = try await loadModelContainer(
+                from: #hubDownloader(),
+                using: #huggingFaceTokenizerLoader(),
+                configuration: Self.configuration
+            ) { progress in
+                Task { @MainActor in
+                    self.loadState = .loading(progress)
+                }
+            }
+            self.container = container
+            loadState = .ready
+        } catch {
+            loadState = .failed(String(describing: error))
+        }
+    }
+
+    /// Streams a response for `prompt` with an optional image attached, reporting
+    /// prompt composition and prefill progress before the first token.
+    /// `maxImageTokens` caps how many merged vision tokens the image may become.
+    /// It is the strongest latency lever available: each one becomes a prompt
+    /// token that must be prefilled, so halving the budget roughly halves
+    /// time-to-first-token. Passed through the model-agnostic `maxPixels` hook,
+    /// where one merged token covers 28x28 pixels.
+    func generate(
+        prompt: String,
+        image: URL?,
+        maxTokens: Int,
+        maxImageTokens: Int
+    ) throws -> AsyncStream<GenerationEvent> {
+        guard let container else {
+            throw MuseGlimmerServiceError.notLoaded
+        }
+
+        let (stream, continuation) = AsyncStream<GenerationEvent>.makeStream()
+
+        let work = Task {
+            do {
+                try await container.perform { (context: ModelContext) in
+                    // `UserInput` is not Sendable, so it is built inside the
+                    // container's isolation rather than captured across it.
+                    let images: [UserInput.Image] = image.map { [.url($0)] } ?? []
+                    let chat = [
+                        Chat.Message(role: .user, content: prompt, images: images, videos: [])
+                    ]
+                    let processing = UserInput.Processing(
+                        maxPixels: maxImageTokens * 28 * 28)
+                    let lmInput = try await context.processor.prepare(
+                        input: UserInput(chat: chat, processing: processing))
+
+                    let imageTokenId =
+                        (context.model as? MuseGlimmer)?.config.imageTokenId ?? 200_092
+                    let tokens = lmInput.text.tokens.asArray(Int.self)
+                    continuation.yield(
+                        .prompt(
+                            total: tokens.count,
+                            image: tokens.count { $0 == imageTokenId }))
+
+                    // Greedy, so the app's output can be compared against the
+                    // Python reference.
+                    var parameters = GenerateParameters(maxTokens: maxTokens, temperature: 0)
+                    // Chunks are pipelined with asyncEval, so this reports graph
+                    // submission and runs slightly ahead of GPU completion. Fine
+                    // for a progress bar; don't read it as a hard timing signal.
+                    parameters.prefill = PrefillParameters(progress: { processed, total in
+                        continuation.yield(.prefill(processed: processed, total: total))
+                    })
+
+                    for await generation in try MLXLMCommon.generate(
+                        input: lmInput, parameters: parameters, context: context)
+                    {
+                        switch generation {
+                        case .chunk(let text):
+                            continuation.yield(.chunk(text))
+                        case .info(let info):
+                            continuation.yield(
+                                .completed(
+                                    promptTime: info.promptTime,
+                                    tokensPerSecond: info.tokensPerSecond,
+                                    peakBytes: Memory.snapshot().peakMemory))
+                        default:
+                            break
+                        }
+                    }
+                }
+            } catch is CancellationError {
+                // Stopped by the user; whatever streamed already stays on screen.
+            } catch {
+                continuation.yield(.failed(String(describing: error)))
+            }
+            continuation.finish()
+        }
+
+        // Cancelling the consumer has to cancel the generation, or a 30B forward
+        // keeps running with nobody reading it.
+        continuation.onTermination = { _ in work.cancel() }
+        return stream
+    }
+}
+
+enum MuseGlimmerServiceError: LocalizedError {
+    case notLoaded
+
+    var errorDescription: String? {
+        switch self {
+        case .notLoaded: "The model is not loaded yet."
+        }
+    }
+}

--- a/Applications/MuseGlimmerDemo/README.md
+++ b/Applications/MuseGlimmerDemo/README.md
@@ -1,0 +1,65 @@
+# MuseGlimmerDemo
+
+Runs [`meta-models/Muse-Glimmer-30B`](https://huggingface.co/meta-models/Muse-Glimmer-30B)
+entirely on-device: drop in an image, ask about it, watch tokens stream. After the
+initial model download there are no network calls.
+
+Build and run the `MuseGlimmerDemo` scheme. **Use the Release configuration** — a
+Debug build of a 30B forward pass is several times slower (first token takes ~21 s
+in Debug versus ~10 s in Release on the same image).
+
+## Requirements
+
+`mlx-community/Muse-Glimmer-30B-4bit` is a 19.4 GB download and sits around
+**19 GB resident** — roughly 3.7 GB of that is the vision tower, which the
+checkpoint leaves unquantized in bf16. A 64 GB machine is comfortable; 32 GB is
+not. Measured on an M4 Max: ~26 tok/s decode, 18.97 GB peak.
+
+The app raises the buffer cache to 2 GB (`Memory.cacheLimit`) in
+`MuseGlimmerService.configureMemory()`. The 20 MB the smaller examples use
+thrashes badly at this size, because a single image encode churns hundreds of MB
+of activations.
+
+## Why there is a wait before the first token
+
+Almost all of the perceived latency is prefill, driven by how many tokens the
+image expands into — not by decode, which is a steady ~26 tok/s. The app reports
+the phase, a prefill progress bar, the prompt composition and time-to-first-token
+so the wait reads as work rather than a hang.
+
+Measured on an M4 Max (Release):
+
+| input | prompt tokens | ViT patches | time to first token |
+|---|---|---|---|
+| 448×448 image | 318 | 1,024 | 1.8 s |
+| 768×1024 image | 1,034 | 3,888 | 5.8–6.6 s |
+| 2400×2400 image | 4,158 | 16,384 | 29–40 s |
+| text only | 4,205 | — | 19–20 s |
+
+Text prefill runs at ~200 tok/s and is the dominant term: an image doesn't just
+cost ViT time, it injects up to 4096 tokens into the prompt and every one goes
+through the 52-layer text stack. Vision encode adds ~1.5 s at 3,888 patches but
+10–20 s at 16,384, superlinear because the ViT's 13 full-attention layers are
+O(L²) in the *unmerged* patch count.
+
+The **Image budget** slider is therefore the strongest latency control. It
+defaults to 1024 merged tokens rather than the checkpoint's 4096, which on the
+2400×2400 sample takes first token from 26.6 s to 7.2 s. It routes through
+`UserInput.Processing.maxPixels`, where one merged token covers 28×28 pixels.
+
+## Notes
+
+- **Reasoning is not observable.** The model reasons under
+  `to=self<|message|>…<|eom|>` before answering under `to=user<|message|>…`. The
+  framework strips those control tokens and withholds reasoning from the public
+  `Generation` stream, and `TokenStreamDecoder` is `package`-level, so an app
+  cannot consume it. The effect is a second silent window after prefill — on the
+  sample image prefill finishes at 5.8 s but the first visible token lands at
+  10.5 s. The status strip names that window rather than leaving the pane blank.
+- **Greedy decoding** (`temperature: 0`) so output can be compared against the
+  Python reference implementation.
+- Single image per turn. Video is rejected explicitly; tool calling and
+  multi-image prompts are not wired up in this app.
+- An image path passed as a launch argument preloads the well, which makes the
+  drop-to-describe flow scriptable. Under the app sandbox only user-selected
+  files are readable, so use drag-and-drop or the file picker normally.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ examples use models implemented in [MLX Swift LM](https://github.com/ml-explore/
 
 - [MLXChatExample](Applications/MLXChatExample/README.md): An example chat app that runs on both iOS and macOS that supports LLMs and VLMs.
 
+- [MuseGlimmerDemo](Applications/MuseGlimmerDemo/README.md): A macOS app that runs
+  the 30B Muse-Glimmer vision-language model fully on-device — drop in an image
+  and ask about it. Shows how to surface prefill progress and cap the image token
+  budget, which dominate latency at this model size.
+
 - [LoRATrainingExample](Applications/LoRATrainingExample/README.md): An example that runs on macOS that downloads an LLM and fine-tunes it using LoRA (Low-Rank Adaptation) with training data.
 
 - [LinearModelTraining](Tools/LinearModelTraining/README.md): An example that

--- a/mlx-swift-examples.xcodeproj/project.pbxproj
+++ b/mlx-swift-examples.xcodeproj/project.pbxproj
@@ -220,6 +220,7 @@
 		C3D9F9452FD36AB50038C3B3 /* HeatTransfer.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = HeatTransfer.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C3D9F9542FD36AE10038C3B3 /* CurveFit.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CurveFit.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		F8D7023A2BB4E223003D7CF5 /* Package.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
+		D6A1C0DE0000000000000A05 /* MuseGlimmerDemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = MuseGlimmerDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -423,13 +424,23 @@
 			);
 			target = C3D9F9352FD36A9B0038C3B3 /* Mandelbrot */;
 		};
+		D6A1C0DE0000000000000A09 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				MuseGlimmerDemo/Assets.xcassets,
+				MuseGlimmerDemo/ContentView.swift,
+				MuseGlimmerDemo/MuseGlimmerDemoApp.swift,
+				MuseGlimmerDemo/MuseGlimmerService.swift,
+			);
+			target = D6A1C0DE0000000000000A01 /* MuseGlimmerDemo */;
+		};
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		C314FCF02EF3313B00E5B73A /* Configuration */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Configuration; sourceTree = "<group>"; };
 		C314FCF62EF3314200E5B73A /* Data */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (C314FCFB2EF3314200E5B73A /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = Data; sourceTree = "<group>"; };
 		C314FD242EF3315100E5B73A /* Tools */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (C314FD422EF3315100E5B73A /* PBXFileSystemSynchronizedBuildFileExceptionSet */, C314FD442EF3315100E5B73A /* PBXFileSystemSynchronizedBuildFileExceptionSet */, C314FD462EF3315100E5B73A /* PBXFileSystemSynchronizedBuildFileExceptionSet */, C314FD432EF3315100E5B73A /* PBXFileSystemSynchronizedBuildFileExceptionSet */, C314FD412EF3315100E5B73A /* PBXFileSystemSynchronizedBuildFileExceptionSet */, C314FD452EF3315100E5B73A /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = Tools; sourceTree = "<group>"; };
-		C314FDA02EF3315A00E5B73A /* Applications */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (C314FDD82EF3315A00E5B73A /* PBXFileSystemSynchronizedBuildFileExceptionSet */, C314FDDA2EF3315A00E5B73A /* PBXFileSystemSynchronizedBuildFileExceptionSet */, C314FEED2EF33B3900E5B73A /* PBXFileSystemSynchronizedBuildFileExceptionSet */, C314FDDD2EF3315A00E5B73A /* PBXFileSystemSynchronizedBuildFileExceptionSet */, C314FDDC2EF3315A00E5B73A /* PBXFileSystemSynchronizedBuildFileExceptionSet */, C314FDDB2EF3315A00E5B73A /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = Applications; sourceTree = "<group>"; };
+		C314FDA02EF3315A00E5B73A /* Applications */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (C314FDD82EF3315A00E5B73A /* PBXFileSystemSynchronizedBuildFileExceptionSet */, C314FDDA2EF3315A00E5B73A /* PBXFileSystemSynchronizedBuildFileExceptionSet */, C314FEED2EF33B3900E5B73A /* PBXFileSystemSynchronizedBuildFileExceptionSet */, C314FDDD2EF3315A00E5B73A /* PBXFileSystemSynchronizedBuildFileExceptionSet */, C314FDDC2EF3315A00E5B73A /* PBXFileSystemSynchronizedBuildFileExceptionSet */, C314FDDB2EF3315A00E5B73A /* PBXFileSystemSynchronizedBuildFileExceptionSet */, D6A1C0DE0000000000000A09 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = Applications; sourceTree = "<group>"; };
 		C397D92E2CD440EF00B87EE2 /* Libraries */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Libraries; sourceTree = "<group>"; };
 		C3D9F9312FD36A810038C3B3 /* Numerical */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (C3D9FB882FD36CDA0038C3B3 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, C3D9FB742FD36CA40038C3B3 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, C3D9FB612FD36C500038C3B3 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = Numerical; sourceTree = "<group>"; };
 /* End PBXFileSystemSynchronizedRootGroup section */
@@ -605,6 +616,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		D6A1C0DE0000000000000A03 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -644,6 +662,7 @@
 				C3D9F9362FD36A9B0038C3B3 /* Mandelbrot.app */,
 				C3D9F9452FD36AB50038C3B3 /* HeatTransfer.app */,
 				C3D9F9542FD36AE10038C3B3 /* CurveFit.app */,
+				D6A1C0DE0000000000000A05 /* MuseGlimmerDemo.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -1041,6 +1060,30 @@
 			productReference = C3D9F9542FD36AE10038C3B3 /* CurveFit.app */;
 			productType = "com.apple.product-type.application";
 		};
+		D6A1C0DE0000000000000A01 /* MuseGlimmerDemo */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = D6A1C0DE0000000000000A06 /* Build configuration list for PBXNativeTarget "MuseGlimmerDemo" */;
+			buildPhases = (
+				D6A1C0DE0000000000000A02 /* Sources */,
+				D6A1C0DE0000000000000A03 /* Frameworks */,
+				D6A1C0DE0000000000000A04 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = MuseGlimmerDemo;
+			packageProductDependencies = (
+				D6A1C0DE0000000000000B01 /* MLXVLM */,
+				D6A1C0DE0000000000000B02 /* MLXLMCommon */,
+				D6A1C0DE0000000000000B03 /* MLXHuggingFace */,
+				D6A1C0DE0000000000000B04 /* HuggingFace */,
+				D6A1C0DE0000000000000B05 /* Tokenizers */,
+			);
+			productName = MuseGlimmerDemo;
+			productReference = D6A1C0DE0000000000000A05 /* MuseGlimmerDemo.app */;
+			productType = "com.apple.product-type.application";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -1142,6 +1185,7 @@
 				C3D9F9352FD36A9B0038C3B3 /* Mandelbrot */,
 				C3D9F9442FD36AB50038C3B3 /* HeatTransfer */,
 				C3D9F9532FD36AE10038C3B3 /* CurveFit */,
+				D6A1C0DE0000000000000A01 /* MuseGlimmerDemo */,
 			);
 		};
 /* End PBXProject section */
@@ -1211,6 +1255,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		C3D9F9522FD36AE10038C3B3 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D6A1C0DE0000000000000A04 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -1333,6 +1384,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		C3D9F9502FD36AE10038C3B3 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D6A1C0DE0000000000000A02 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -3711,6 +3769,105 @@
 			};
 			name = Release;
 		};
+		D6A1C0DE0000000000000A07 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_ENTITLEMENTS = Applications/MuseGlimmerDemo/MuseGlimmerDemo.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "";
+				ENABLE_APP_SANDBOX = YES;
+				ENABLE_FILE_ACCESS_DOWNLOADS_FOLDER = readwrite;
+				ENABLE_INCOMING_NETWORK_CONNECTIONS = NO;
+				ENABLE_OUTGOING_NETWORK_CONNECTIONS = YES;
+				ENABLE_PREVIEWS = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				ENABLE_USER_SELECTED_FILES = readonly;
+				GENERATE_INFOPLIST_FILE = YES;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 26.2;
+				MARKETING_VERSION = 1.0;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "mlx.MuseGlimmerDemo${DISAMBIGUATOR}";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = macosx;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 6.0;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		D6A1C0DE0000000000000A08 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_ENTITLEMENTS = Applications/MuseGlimmerDemo/MuseGlimmerDemo.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "";
+				ENABLE_APP_SANDBOX = YES;
+				ENABLE_FILE_ACCESS_DOWNLOADS_FOLDER = readwrite;
+				ENABLE_INCOMING_NETWORK_CONNECTIONS = NO;
+				ENABLE_OUTGOING_NETWORK_CONNECTIONS = YES;
+				ENABLE_PREVIEWS = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				ENABLE_USER_SELECTED_FILES = readonly;
+				GENERATE_INFOPLIST_FILE = YES;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 26.2;
+				MARKETING_VERSION = 1.0;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "mlx.MuseGlimmerDemo${DISAMBIGUATOR}";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = macosx;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 6.0;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SWIFT_COMPILATION_MODE = wholemodule;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -3872,6 +4029,15 @@
 			buildConfigurations = (
 				C3D9F95D2FD36AE20038C3B3 /* Debug */,
 				C3D9F95E2FD36AE20038C3B3 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		D6A1C0DE0000000000000A06 /* Build configuration list for PBXNativeTarget "MuseGlimmerDemo" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D6A1C0DE0000000000000A07 /* Debug */,
+				D6A1C0DE0000000000000A08 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -4188,6 +4354,28 @@
 			productName = HuggingFace;
 		};
 		C3EA7F742F8445EE0054AEA3 /* Tokenizers */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C3EA7F532F8432080054AEA3 /* XCRemoteSwiftPackageReference "swift-transformers" */;
+			productName = Tokenizers;
+		};
+		D6A1C0DE0000000000000B01 /* MLXVLM */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = MLXVLM;
+		};
+		D6A1C0DE0000000000000B02 /* MLXLMCommon */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = MLXLMCommon;
+		};
+		D6A1C0DE0000000000000B03 /* MLXHuggingFace */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = MLXHuggingFace;
+		};
+		D6A1C0DE0000000000000B04 /* HuggingFace */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C3EA7F522F8431BE0054AEA3 /* XCRemoteSwiftPackageReference "swift-huggingface" */;
+			productName = HuggingFace;
+		};
+		D6A1C0DE0000000000000B05 /* Tokenizers */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = C3EA7F532F8432080054AEA3 /* XCRemoteSwiftPackageReference "swift-transformers" */;
 			productName = Tokenizers;

--- a/mlx-swift-examples.xcodeproj/xcshareddata/xcschemes/MuseGlimmerDemo.xcscheme
+++ b/mlx-swift-examples.xcodeproj/xcshareddata/xcschemes/MuseGlimmerDemo.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2620"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D6A1C0DE0000000000000A01"
+               BuildableName = "MuseGlimmerDemo.app"
+               BlueprintName = "MuseGlimmerDemo"
+               ReferencedContainer = "container:mlx-swift-examples.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D6A1C0DE0000000000000A01"
+            BuildableName = "MuseGlimmerDemo.app"
+            BlueprintName = "MuseGlimmerDemo"
+            ReferencedContainer = "container:mlx-swift-examples.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D6A1C0DE0000000000000A01"
+            BuildableName = "MuseGlimmerDemo.app"
+            BlueprintName = "MuseGlimmerDemo"
+            ReferencedContainer = "container:mlx-swift-examples.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
## Proposed changes

Adds `MuseGlimmerDemo`, a macOS app that runs [`meta-models/Muse-Glimmer-30B`](https://huggingface.co/meta-models/Muse-Glimmer-30B) (Apache-2.0) fully on-device: drop in an image, ask about it, watch tokens stream. No network calls after the initial download.

**Draft, and blocked.** It needs the `muse_glimmer` model from ml-explore/mlx-swift-lm#523, which isn't in a tagged release, so this cannot compile against the `mlx-swift-lm` 3.31.3 pin. I've kept the package reference untouched here rather than pointing it anywhere temporary. Once #523 merges and a release is tagged, the pin gets raised and this is ready. Everything below was verified locally against that branch.

Modelled on `LLMBasic`: sources come from the synchronized `Applications` group via a membership exception set, the Info.plist is generated, and the target is macOS-only since the UI uses AppKit for the file picker and thumbnails.

### What this example is for

Two behaviours that only become visible at this model size, and that I couldn't find demonstrated in the existing examples:

**1. Prefill dominates perceived latency, and an image drives it.** Each merged vision token becomes a prompt token that must be prefilled through all 52 text layers at ~200 tok/s, while decode runs at a steady ~26 tok/s throughout. Measured on an M4 Max (Release):

| input | prompt tokens | ViT patches | time to first token |
|---|---|---|---|
| 448×448 image | 318 | 1,024 | 1.8 s |
| 768×1024 image | 1,034 | 3,888 | 5.8–6.6 s |
| 2400×2400 image | 4,158 | 16,384 | 29–40 s |
| text only | 4,205 | — | 19–20 s |

The text-only rows are the control: the text stack is the dominant term, not the ViT. So the app reports the phase, a prefill progress bar, the prompt composition (how many tokens came from the image) and time-to-first-token, so a long wait reads as work rather than a hang.

**2. The image token budget is the strongest latency control.** The **Image budget** slider defaults to 1024 merged tokens rather than the checkpoint's 4096, which on the 2400×2400 sample takes first token from 26.6 s to 7.2 s with no meaningful loss in the description. It routes through `UserInput.Processing.maxPixels`, the existing model-agnostic per-call resize budget, where one merged token covers 28×28 pixels.

It also raises the buffer cache to 2 GB. The 20 MB the smaller examples use thrashes badly against a ~19 GB resident model, because a single image encode churns hundreds of MB of activations.

### Notes for reviewers

- **Reasoning is not shown, because it can't be.** The model reasons under `to=self<|message|>…<|eom|>` before answering. `TextToolTokenLoopHandler` withholds reasoning from the public `Generation` stream and `TokenStreamDecoder` is `package`-level, so an app can't consume it. That creates a *second* silent window after prefill (prefill ends at 5.8 s; first visible token at 10.5 s). The status strip names that window rather than leaving the pane blank. Discussion in ml-explore/mlx-swift-lm#523.
- **Build Release.** A Debug build of a 30B forward is several times slower — 21 s to first token versus ~10 s on the same image.
- Requires ~19 GB resident (19.4 GB download; ~3.7 GB of it is the bf16 vision tower the checkpoint leaves unquantized). 64 GB is comfortable, 32 GB is not.
- Single image per turn. Video is rejected explicitly; tool calling and multi-image are not wired up in the app.
- Unrelated but worth flagging: `mlx-swift-lm` declares `.upToNextMinor(from: "0.31.4")` for `mlx-swift`, but its code calls `DType.greatestFiniteMagnitudeArray`, which needs 0.31.6. A plain re-resolve picks 0.31.4 and fails to compile. That floor should be raised upstream.

### Verification

Built and ran the app from this project against the `muse_glimmer` branch, with an image, confirming coherent streaming output, the prefill/reasoning status phases, and 18.97 GB peak. Confirmed `MLXChatExample`, `LLMBasic` and `LLMEval` still build. `pre-commit run --all-files` passes.

Note that `xcodebuild` from the CLI fails with "entitlements that require signing with a development certificate" — this is pre-existing and not specific to this target (`LLMBasic` fails identically); it builds from Xcode with a development team selected.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx-swift-examples/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
